### PR TITLE
Comment out tests that take way too long to run

### DIFF
--- a/xt/sandbox/subscription_search.t
+++ b/xt/sandbox/subscription_search.t
@@ -139,13 +139,12 @@ subtest "each (single value)" => sub {
                                                                         shift->id->is("subscription1_$id");
                                                                     });
 
-    my @subscriptions = ();
-    $search_result->each(sub {
-                             push(@subscriptions, shift);
-                         });
-
-  TODO: {
+   TODO: {
         todo_skip "Tests consistently fail in sandbox environment", 1;
+        my @subscriptions = ();
+        $search_result->each(sub {
+            push(@subscriptions, shift);
+        });
         is_deeply \@subscriptions, [$subscription_active];
     }
     ;

--- a/xt/sandbox/transaction_search.t
+++ b/xt/sandbox/transaction_search.t
@@ -117,6 +117,7 @@ subtest "result 'each'" => sub {
 
         ok contains($sale1->transaction->id, \@results);
         ok contains($sale2->transaction->id, \@results);
+        is scalar(@results), 2;
     };
 };
 
@@ -132,9 +133,9 @@ subtest "credit_card_card_type - multiple value field" => sub {
     });
 
     ok contains($find->id, $search_result->ids);
-    my @results = ();
-    $search_result->each(sub { push(@results, shift->id); });
-    ok contains($find->id, \@results);
+    #my @results = ();
+    #$search_result->each(sub { push(@results, shift->id); });
+    #ok contains($find->id, \@results);
 };
 
 subtest "credit_card_card_type - multiple value field - passing invalid credit_card_card_type" => sub {
@@ -167,9 +168,9 @@ subtest "status - multiple value field" => sub {
     });
 
     ok contains($find->id, $search_result->ids);
-    my @results = ();
-    $search_result->each(sub { push(@results, shift->id); });
-    ok contains($find->id, \@results);
+    #my @results = ();
+    #$search_result->each(sub { push(@results, shift->id); });
+    #ok contains($find->id, \@results);
 };
 
 subtest "source - multiple value field - passing invalid source" => sub {
@@ -192,9 +193,9 @@ subtest "source - multiple value field" => sub {
     });
 
     ok contains($find->id, $search_result->ids);
-    my @results = ();
-    $search_result->each(sub { push(@results, shift->id); });
-    ok contains($find->id, \@results);
+    #my @results = ();
+    #$search_result->each(sub { push(@results, shift->id); });
+    #ok contains($find->id, \@results);
 };
 
 subtest "type - multiple value field - passing invalid type" => sub {
@@ -206,8 +207,6 @@ subtest "type - multiple value field - passing invalid type" => sub {
     }
 };
 
-# Something about this kind of test is failing horribly
-# Compare against master and bisect what is actually hanging
 subtest "type - multiple value field" => sub {
     my $unique = generate_unique_integer() . "status";
     my $sale1 = create_sale($unique);
@@ -219,9 +218,9 @@ subtest "type - multiple value field" => sub {
     });
 
     ok contains($find->id, $search_result->ids);
-    my @results = ();
-    $search_result->each(sub { push(@results, shift->id); });
-    ok contains($find->id, \@results);
+    #my @results = ();
+    #$search_result->each(sub { push(@results, shift->id); });
+    #ok contains($find->id, \@results);
 };
 
 subtest "credit card number - partial match" => sub {


### PR DESCRIPTION
Commenting out these lines results in an average run for the integration tests of about 387.5 seconds over 4 full runs. The root cause is the transaction_search.t (which still takes the longest at around 100 seconds) creates several new transactions every run. Then, we have the following lines in several places:

```perl
    ok contains($find->id, $search_result->ids);
    my @results = ();
    $search_result->each(sub { push(@results, shift->id); });
    ok contains($find->id, \@results);
```

The problem comes when there are 3800+ transactions that are pulled in. This results in 3800/page_size calls to TransactionGateway::fetch_transactions(). This is what takes these tests so freaking long.

We still have 5 xt/ tests that average 20s or more:

- transaction_search (~100)
- payment_method (~70)
- transaction (~40)
- credit_card (~35)
- customer (~25)

The rest of the test suite takes about 2 minutes to run. These 5 take the other 5ish minutes. Part of it is that these have many more subtests and create more complex preconditions. I'm not sure how much faster it makes sense to make these now that we're consistently under 7 minutes.