### PR TITLE
General cleanup (part 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ sandbox_config.json
 .build
 test_diffs
 build_log
+Dockerfile.5*

--- a/dist.ini
+++ b/dist.ini
@@ -44,7 +44,6 @@ MIME::Base64 = 0
 Module::Install::TestTarget = 0
 Moose = 0
 Mozilla::CA = 0
-Ref::Util = 0
 Scalar::Util = 0
 URI::Query = 0
 XML::Simple = 0

--- a/dist.ini
+++ b/dist.ini
@@ -44,12 +44,16 @@ MIME::Base64 = 0
 Module::Install::TestTarget = 0
 Moose = 0
 Mozilla::CA = 0
+Ref::Util = 0
+Scalar::Util = 0
 URI::Query = 0
 XML::Simple = 0
 JSON = 0
+
 [Prereqs / TestRequires]
 Test::More = 0.98
 Try::Tiny = 0
 Test::Warn = 0
 Test::Pod = 0
 Test::Moose = 0
+Test::Deep = 0

--- a/lib/WebService/Braintree/AdvancedSearch.pm
+++ b/lib/WebService/Braintree/AdvancedSearch.pm
@@ -1,14 +1,10 @@
 package WebService::Braintree::AdvancedSearch;
 
-
 use strict;
-use vars qw(@ISA @EXPORT_OK);
-use Exporter;
-our @ISA = qw(Exporter);
-our @EXPORT_OK = qw(search_to_hash);
 
 sub search_to_hash {
-    my ($self,$search) = @_;
+    my ($self, $search) = @_;
+
     my $hash = {};
     for my $attribute ($search->meta()->get_all_attributes) {
         my $field = $attribute->name;
@@ -16,6 +12,7 @@ sub search_to_hash {
             $hash->{$field} = $search->$field->criteria;
         }
     }
+
     return $hash;
 }
 

--- a/lib/WebService/Braintree/AdvancedSearchNodes.pm
+++ b/lib/WebService/Braintree/AdvancedSearchNodes.pm
@@ -149,7 +149,7 @@
 
     use Carp;
     use Moose;
-    use WebService::Braintree::Util qw(difference_arrays);
+    use WebService::Braintree::Util qw(difference_arrays is_arrayref);
     extends ("WebService::Braintree::SearchNode");
 
     has 'allowed_values' => (is => 'rw');
@@ -170,7 +170,7 @@
     sub _args_to_array {
         my $self = shift;
         my @args;
-        if (ref($_[0]) eq 'ARRAY') {
+        if (is_arrayref($_[0])) {
             @args = @{$_[0]};
         } else {
             @args = @_;

--- a/lib/WebService/Braintree/AdvancedSearchNodes.pm
+++ b/lib/WebService/Braintree/AdvancedSearchNodes.pm
@@ -149,7 +149,7 @@
 
     use Carp;
     use Moose;
-    use WebService::Braintree::Util;
+    use WebService::Braintree::Util qw(difference_arrays);
     extends ("WebService::Braintree::SearchNode");
 
     has 'allowed_values' => (is => 'rw');

--- a/lib/WebService/Braintree/Configuration.pm
+++ b/lib/WebService/Braintree/Configuration.pm
@@ -96,66 +96,85 @@ has environment => (
     is => 'rw',
     trigger => sub {
         my ($self, $new_value, $old_value) = @_;
-        if ($new_value !~ /integration|development|sandbox|production|qa/) {
-            warn "Assigned invalid value to WebService::Braintree::Configuration::environment";
+        my %valid = map { $_ => 1 } qw(
+            development integration sandbox qa production
+        );
+        if (!$valid{$new_value}) {
+            warn 'Assigned invalid value to WebService::Braintree::Configuration::environment';
         }
-        if ($new_value eq "integration") {
-            $self->public_key("integration_public_key");
-            $self->private_key("integration_private_key");
-            $self->merchant_id("integration_merchant_id");
+
+        if ($new_value eq 'integration') {
+            $self->public_key('integration_public_key');
+            $self->private_key('integration_private_key');
+            $self->merchant_id('integration_merchant_id');
         }
     }
 );
 
 has gateway => (is  => 'ro', lazy => 1, default => sub {
-    WebService::Braintree::Gateway->new({config => shift})
+    WebService::Braintree::Gateway->new({config => shift});
 });
 
-sub base_merchant_path {
-    my $self = shift;
-    return "/merchants/" . $self->merchant_id;
-}
-
+# This method is used in ::HTTP
 sub base_merchant_url {
     my $self = shift;
     return $self->base_url() . $self->base_merchant_path;
 }
 
+# Below here, these methods do *NOT* appear to be used outside of this class.
+
+sub base_merchant_path {
+    my $self = shift;
+    return '/merchants/' . $self->merchant_id;
+}
+
 sub base_url {
     my $self = shift;
-    return $self->protocol . "://" . $self->server . ':' . $self->port;
+    return $self->protocol . '://' . $self->server . ':' . $self->port;
+}
+
+sub is_development {
+    my $self = shift;
+    return 1 if $self->environment eq 'development';
+    return 1 if $self->environment eq 'integration';
+    return;
 }
 
 sub port {
     my $self = shift;
-    if ($self->environment =~ /integration|development/) {
-        return $ENV{'GATEWAY_PORT'} || "3000"
+    if ($self->is_development) {
+        return $ENV{'GATEWAY_PORT'} || '3000'
     } else {
-        return "443";
+        return 443;
     }
 }
 
 sub server {
     my $self = shift;
-    return "localhost" if $self->environment eq 'integration';
-    return "localhost" if $self->environment eq 'development';
-    return "api.sandbox.braintreegateway.com" if $self->environment eq 'sandbox';
-    return "api.braintreegateway.com" if $self->environment eq 'production';
-    return "qa-master.braintreegateway.com" if $self->environment eq 'qa';
+    return {
+        development => 'localhost',
+        integration => 'localhost',
+        sandbox     => 'api.sandbox.braintreegateway.com',
+        qa          => 'qa-master.braintreegateway.com',
+        production  => 'api.braintreegateway.com',
+    }->{$self->environment};
 }
 
 sub auth_url {
     my $self = shift;
-    return "http://auth.venmo.dev:9292" if $self->environment eq 'integration';
-    return "http://auth.venmo.dev:9292" if $self->environment eq 'development';
-    return "https://auth.sandbox.venmo.com" if $self->environment eq 'sandbox';
-    return "https://auth.venmo.com" if $self->environment eq 'production';
-    return "https://auth.qa.venmo.com" if $self->environment eq 'qa';
+    return {
+        development => 'http://auth.venmo.dev:9292',
+        integration => 'http://auth.venmo.dev:9292',
+        sandbox     => 'https://auth.sandbox.venmo.com',
+        qa          => 'https://auth.qa.venmo.com',
+        production  => 'https://auth.venmo.com',
+    }->{$self->environment};
 }
+
 
 sub ssl_enabled {
     my $self = shift;
-    return ($self->environment !~ /integration|development/);
+    return ! $self->is_development;
 }
 
 sub protocol {
@@ -173,6 +192,7 @@ This returns the Braintree API version this distribution speaks.
 
 =cut
 
+# This method is used in ::HTTP
 sub api_version {
     return "4";
 }

--- a/lib/WebService/Braintree/CreditCard.pm
+++ b/lib/WebService/Braintree/CreditCard.pm
@@ -101,10 +101,15 @@ object of type L<WebService::Braintree::Address/>.
 has billing_address => (is => 'rw');
 
 sub BUILD {
-    my ($self, $attributes) = @_;
-    $self->billing_address(WebService::Braintree::Address->new($attributes->{billing_address})) if ref($attributes->{billing_address}) eq 'HASH';
-    delete($attributes->{billing_address});
-    $self->set_attributes_from_hash($self, $attributes);
+    my ($self, $attrs) = @_;
+
+    $self->build_sub_object($attrs,
+        method => 'billing_address',
+        class  => 'Address',
+        key    => 'billing_address',
+    );
+
+    $self->set_attributes_from_hash($self, $attrs);
 }
 
 =head2 masked_number()

--- a/lib/WebService/Braintree/CreditCardVerificationGateway.pm
+++ b/lib/WebService/Braintree/CreditCardVerificationGateway.pm
@@ -2,7 +2,7 @@ package WebService::Braintree::CreditCardVerificationGateway;
 
 use Moose;
 use WebService::Braintree::CreditCardVerificationSearch;
-use WebService::Braintree::Util;
+use WebService::Braintree::Util qw(validate_id to_instance_array);
 use Carp qw(confess);
 
 has 'gateway' => (is => 'ro');

--- a/lib/WebService/Braintree/CustomerGateway.pm
+++ b/lib/WebService/Braintree/CustomerGateway.pm
@@ -5,9 +5,8 @@ with 'WebService::Braintree::Role::MakeRequest';
 
 use Carp qw(confess);
 use WebService::Braintree::Validations qw(verify_params customer_signature);
-use WebService::Braintree::Util qw(validate_id);
+use WebService::Braintree::Util qw(to_instance_array validate_id);
 use WebService::Braintree::Result;
-use WebService::Braintree::Util;
 
 has 'gateway' => (is => 'ro');
 

--- a/lib/WebService/Braintree/CustomerGateway.pm
+++ b/lib/WebService/Braintree/CustomerGateway.pm
@@ -39,8 +39,8 @@ sub search {
     my $params = $block->($search)->to_hash;
     my $response = $self->gateway->http->post("/customers/advanced_search_ids", {search => $params});
     return WebService::Braintree::ResourceCollection->new()->init($response, sub {
-                                                                      $self->fetch_customers($search, shift);
-                                                                  });
+        $self->fetch_customers($search, shift);
+    });
 }
 
 sub all {

--- a/lib/WebService/Braintree/CustomerGateway.pm
+++ b/lib/WebService/Braintree/CustomerGateway.pm
@@ -47,8 +47,10 @@ sub all {
     my $self = shift;
     my $response = $self->gateway->http->post("/customers/advanced_search_ids");
     return WebService::Braintree::ResourceCollection->new()->init($response, sub {
-                                                                      $self->fetch_customers(WebService::Braintree::CustomerSearch->new, shift);
-                                                                  });
+        $self->fetch_customers(
+            WebService::Braintree::CustomerSearch->new, shift,
+        );
+    });
 }
 
 sub fetch_customers {

--- a/lib/WebService/Braintree/Digest.pm
+++ b/lib/WebService/Braintree/Digest.pm
@@ -8,11 +8,23 @@ use Digest::SHA256;
 use Digest::SHA qw(hmac_sha256_hex);
 use WebService::Braintree::DigestSHA256;
 
-use vars qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS );
+use vars qw(@ISA @EXPORT @EXPORT_OK);
 use Exporter;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(hexdigest hexdigest_256);
 our @EXPORT_OK = qw();
+
+sub hexdigest {
+    my($key, $data) = @_;
+    return _hexdigest($key, $data, "SHA-1");
+}
+
+sub hexdigest_256 {
+    my($key, $data) = @_;
+    return _hexdigest($key, $data, "SHA-256");
+}
+
+# Methods below here are only used within this class.
 
 sub algo_class {
     my ($algo) = @_;
@@ -26,16 +38,6 @@ sub algo_class {
 sub hmac {
     my($key, $algo) = @_;
     return Digest::HMAC->new($key, algo_class($algo));
-}
-
-sub hexdigest {
-    my($key, $data) = @_;
-    return _hexdigest($key, $data, "SHA-1");
-}
-
-sub hexdigest_256 {
-    my($key, $data) = @_;
-    return _hexdigest($key, $data, "SHA-256");
 }
 
 sub _hexdigest {
@@ -53,6 +55,7 @@ sub key_digest {
     return $sha->digest;
 }
 
+# UNUSED?
 sub secure_compare {
     my ($left, $right) = @_;
 

--- a/lib/WebService/Braintree/Dispute.pm
+++ b/lib/WebService/Braintree/Dispute.pm
@@ -26,11 +26,15 @@ This class is B<NOT> an interface, so it does B<NOT> have any class methods.
 =cut
 
 sub BUILD {
-    my ($self, $attributes) = @_;
+    my ($self, $attrs) = @_;
 
-    $self->transaction_details(WebService::Braintree::Dispute::TransactionDetails->new($attributes->{transaction})) if ref($attributes->{transaction}) eq 'HASH';
-    delete($attributes->{transaction});
-    $self->set_attributes_from_hash($self, $attributes);
+    $self->build_sub_object($attrs,
+        method => 'transaction_details',
+        class  => 'Dispute::TransactionDetails',
+        key    => 'transaction',
+    );
+
+    $self->set_attributes_from_hash($self, $attrs);
 }
 
 =pod

--- a/lib/WebService/Braintree/HTTP.pm
+++ b/lib/WebService/Braintree/HTTP.pm
@@ -2,7 +2,9 @@ package WebService::Braintree::HTTP;
 
 use HTTP::Request;
 use LWP::UserAgent;
-use WebService::Braintree::Xml;
+
+use WebService::Braintree::Xml qw(hash_to_xml xml_to_hash);
+
 use Moose;
 use Carp qw(confess);
 use constant CLIENT_VERSION => $WebService::Braintree::VERSION || 'development';
@@ -11,22 +13,22 @@ has 'config' => (is => 'ro', default => sub { WebService::Braintree->configurati
 
 sub post {
     my ($self, $path, $params) = @_;
-    $self -> make_request($path, $params, 'POST');
+    $self->make_request($path, $params, 'POST');
 }
 
 sub put {
     my ($self, $path, $params) = @_;
-    $self -> make_request($path, $params, 'PUT');
+    $self->make_request($path, $params, 'PUT');
 }
 
 sub get {
     my ($self, $path, $params) = @_;
-    $self -> make_request($path, $params, 'GET');
+    $self->make_request($path, $params, 'GET');
 }
 
 sub delete {
     my ($self, $path, $params) = @_;
-    $self -> make_request($path, undef, 'DELETE');
+    $self->make_request($path, undef, 'DELETE');
 }
 
 sub make_request {

--- a/lib/WebService/Braintree/MerchantAccount.pm
+++ b/lib/WebService/Braintree/MerchantAccount.pm
@@ -115,24 +115,33 @@ will be a L<WebService::Braintree::MerchantAccount::FundingDetails> object.
 has funding_details => (is => 'rw');
 
 sub BUILD {
-    my ($self, $attributes) = @_;
+    my ($self, $attrs) = @_;
 
-    $self->master_merchant_account(WebService::Braintree::MerchantAccount->new($attributes->{master_merchant_account})) if ref($attributes->{master_merchant_account}) eq 'HASH';
-    delete($attributes->{master_merchant_account});
+    $self->build_sub_object($attrs,
+        method => 'master_merchant_account',
+        class  => 'MerchantAccount',
+        key    => 'master_merchant_account',
+    );
 
+    $self->build_sub_object($attrs,
+        method => 'individual_details',
+        class  => 'MerchantAccount::IndividualDetails',
+        key    => 'individual',
+    );
 
-    $self->individual_details(WebService::Braintree::MerchantAccount::IndividualDetails->new($attributes->{individual})) if ref($attributes->{individual}) eq 'HASH';
-    delete($attributes->{individual});
+    $self->build_sub_object($attrs,
+        method => 'business_details',
+        class  => 'MerchantAccount::BusinessDetails',
+        key    => 'business',
+    );
 
+    $self->build_sub_object($attrs,
+        method => 'funding_details',
+        class  => 'MerchantAccount::FundingDetails',
+        key    => 'funding',
+    );
 
-    $self->business_details(WebService::Braintree::MerchantAccount::BusinessDetails->new($attributes->{business})) if ref($attributes->{business}) eq 'HASH';
-    delete($attributes->{business});
-
-
-    $self->funding_details(WebService::Braintree::MerchantAccount::FundingDetails->new($attributes->{funding})) if ref($attributes->{funding}) eq 'HASH';
-    delete($attributes->{funding});
-
-    $self->set_attributes_from_hash($self, $attributes);
+    $self->set_attributes_from_hash($self, $attrs);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/WebService/Braintree/MerchantAccount/BusinessDetails.pm
+++ b/lib/WebService/Braintree/MerchantAccount/BusinessDetails.pm
@@ -8,11 +8,15 @@ extends "WebService::Braintree::ResultObject";
 has  address_details => (is => 'rw');
 
 sub BUILD {
-    my ($self, $attributes) = @_;
-    $self->address_details(WebService::Braintree::MerchantAccount::AddressDetails->new($attributes->{address})) if ref($attributes->{address}) eq 'HASH';
-    delete($attributes->{address});
+    my ($self, $attrs) = @_;
 
-    $self->set_attributes_from_hash($self, $attributes);
+    $self->build_sub_object($attrs,
+        method => 'address_details',
+        class  => 'MerchantAccount::AddressDetails',
+        key    => 'address',
+    );
+
+    $self->set_attributes_from_hash($self, $attrs);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/WebService/Braintree/MerchantAccount/IndividualDetails.pm
+++ b/lib/WebService/Braintree/MerchantAccount/IndividualDetails.pm
@@ -8,10 +8,15 @@ extends "WebService::Braintree::ResultObject";
 has  address_details => (is => 'rw');
 
 sub BUILD {
-    my ($self, $attributes) = @_;
-    $self->address_details(WebService::Braintree::MerchantAccount::AddressDetails->new($attributes->{address})) if ref($attributes->{address}) eq 'HASH';
-    delete($attributes->{address});
-    $self->set_attributes_from_hash($self, $attributes);
+    my ($self, $attrs) = @_;
+
+    $self->build_sub_object($attrs,
+        method => 'address_details',
+        class  => 'MerchantAccount::AddressDetails',
+        key    => 'address',
+    );
+
+    $self->set_attributes_from_hash($self, $attrs);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/WebService/Braintree/MerchantAccountGateway.pm
+++ b/lib/WebService/Braintree/MerchantAccountGateway.pm
@@ -5,7 +5,7 @@ with 'WebService::Braintree::Role::MakeRequest';
 
 use Carp qw(confess);
 use WebService::Braintree::Validations qw(verify_params);
-use WebService::Braintree::Util qw(validate_id);
+use WebService::Braintree::Util qw(validate_id is_hashref);
 use WebService::Braintree::Result;
 
 has 'gateway' => (is => 'ro');
@@ -30,7 +30,7 @@ sub find {
 
 sub _detect_signature {
     my ($params) = @_;
-    if (ref($params->{applicant_details}) eq 'HASH') {
+    if (is_hashref($params->{applicant_details})) {
         warnings::warnif("deprecated", "[DEPRECATED] Passing applicant_details to create is deprecated. Please use individual, business, and funding.");
         return _deprecated_create_signature();
     } else {

--- a/lib/WebService/Braintree/PaymentMethodGateway.pm
+++ b/lib/WebService/Braintree/PaymentMethodGateway.pm
@@ -7,6 +7,8 @@ use Carp qw(confess);
 
 has 'gateway' => (is => 'ro');
 
+use WebService::Braintree::Util qw(validate_id);
+
 sub create {
     my ($self, $params) = @_;
     $self->_make_request("/payment_methods", 'post', {payment_method => $params});
@@ -24,7 +26,7 @@ sub delete {
 
 sub find {
     my ($self, $token) = @_;
-    if (!defined($token) || WebService::Braintree::Util::trim($token) eq "") {
+    if (!validate_id($token)) {
         confess "NotFoundError";
     }
 

--- a/lib/WebService/Braintree/PaymentMethodNonceGateway.pm
+++ b/lib/WebService/Braintree/PaymentMethodNonceGateway.pm
@@ -3,11 +3,13 @@ package WebService::Braintree::PaymentMethodNonceGateway;
 use Moose;
 with 'WebService::Braintree::Role::MakeRequest';
 
+use WebService::Braintree::Util qw(validate_id);
+
 has 'gateway' => (is => 'ro');
 
 sub create {
     my ($self, $token) = @_;
-    if (!defined($token) || WebService::Braintree::Util::trim($token) eq "") {
+    if (!validate_id($token)) {
         confess "NotFoundError";
     }
     my $response = $self->_make_request("/payment_methods/${token}/nonces", 'post');
@@ -16,7 +18,7 @@ sub create {
 
 sub find {
     my ($self, $token) = @_;
-    if (!defined($token) || WebService::Braintree::Util::trim($token) eq "") {
+    if (!validate_id($token)) {
         confess "NotFoundError";
     }
 

--- a/lib/WebService/Braintree/ResourceCollection.pm
+++ b/lib/WebService/Braintree/ResourceCollection.pm
@@ -37,7 +37,7 @@ sub is_empty {
 
 sub maximum_size {
     my $self = shift;
-    return (scalar @{$self->ids});
+    return (scalar @{$self->ids || []});
 }
 
 sub each {

--- a/lib/WebService/Braintree/Result.pm
+++ b/lib/WebService/Braintree/Result.pm
@@ -3,6 +3,8 @@ package WebService::Braintree::Result;
 use Moose;
 use Hash::Inflator;
 
+use WebService::Braintree::Util qw(is_hashref);
+
 # XXX: Why only these classes?
 use WebService::Braintree::ValidationErrorCollection;
 use WebService::Braintree::CreditCardVerification;
@@ -37,7 +39,7 @@ sub _get_response {
 sub patch_in_response_accessors {
     my $field_rules = shift;
     while (my($key, $rule) = each(%$field_rules)) {
-        if (ref($rule) eq "HASH") {
+        if (is_hashref($rule)) {
             $meta->add_method($key, sub {
                                   my $self = shift;
                                   my $response = $self->_get_response();

--- a/lib/WebService/Braintree/Result.pm
+++ b/lib/WebService/Braintree/Result.pm
@@ -2,7 +2,9 @@ package WebService::Braintree::Result;
 
 use Moose;
 use Hash::Inflator;
-use WebService::Braintree::Util;
+#use WebService::Braintree::Util;
+
+# XXX: Why only these classes?
 use WebService::Braintree::ValidationErrorCollection;
 use WebService::Braintree::CreditCardVerification;
 use WebService::Braintree::Nonce;
@@ -20,7 +22,7 @@ my $response_objects = {
         credit_card => "WebService::Braintree::CreditCard",
         paypal_account => "WebService::Braintree::PayPalAccount"
     },
-    payment_method_nonce => "WebService::Braintree::Nonce",
+    payment_method_nonce => 'WebService::Braintree::Nonce',
     settlement_batch_summary => "WebService::Braintree::SettlementBatchSummary",
     subscription => "WebService::Braintree::Subscription",
     transaction => "WebService::Braintree::Transaction",

--- a/lib/WebService/Braintree/Result.pm
+++ b/lib/WebService/Braintree/Result.pm
@@ -2,7 +2,6 @@ package WebService::Braintree::Result;
 
 use Moose;
 use Hash::Inflator;
-#use WebService::Braintree::Util;
 
 # XXX: Why only these classes?
 use WebService::Braintree::ValidationErrorCollection;

--- a/lib/WebService/Braintree/ResultObject.pm
+++ b/lib/WebService/Braintree/ResultObject.pm
@@ -2,7 +2,6 @@ package WebService::Braintree::ResultObject;
 
 use Moose;
 use WebService::Braintree::Util qw(is_arrayref is_hashref);
-use Scalar::Util qw(blessed);
 
 sub set_attributes_from_hash {
     my ($self, $target, $attributes) = @_;
@@ -15,10 +14,7 @@ sub set_attributes_from_hash {
 sub set_attr_value {
     my ($self, $value) = @_;
 
-    if (blessed($value)) {
-        return $value;
-    }
-    elsif (is_hashref($value)) {
+    if (is_hashref($value)) {
         return Hash::Inflator->new($value);
     } elsif (is_arrayref($value)) {
         my $new_array = [];

--- a/lib/WebService/Braintree/Transaction.pm
+++ b/lib/WebService/Braintree/Transaction.pm
@@ -219,22 +219,29 @@ will be a L<WebService::Braintree::Subscription> object.
 has subscription => (is => 'rw');
 
 sub BUILD {
-    my ($self, $attributes) = @_;
-    my $sub_objects = {
+    my ($self, $attrs) = @_;
+
+    $self->build_sub_object($attrs,
+        method => 'subscription',
+        class  => 'Subscription',
+        key    => 'subscription',
+    );
+    $self->build_sub_object($attrs,
+        method => 'disbursement_details',
+        class  => 'DisbursementDetails',
+        key    => 'disbursement_details',
+    );
+    $self->build_sub_object($attrs,
+        method => 'paypal_details',
+        class  => 'PayPalDetails',
+        key    => 'paypal',
+    );
+
+    $self->setup_sub_objects($self, $attrs, {
         disputes => 'WebService::Braintree::Dispute',
-    };
+    });
 
-    $self->subscription(WebService::Braintree::Subscription->new($attributes->{subscription})) if ref($attributes->{subscription}) eq 'HASH';
-    delete($attributes->{subscription});
-
-    $self->disbursement_details(WebService::Braintree::DisbursementDetails->new($attributes->{disbursement_details})) if ref($attributes->{disbursement_details}) eq 'HASH';
-    delete($attributes->{disbursement_details});
-
-    $self->paypal_details(WebService::Braintree::PayPalDetails->new($attributes->{paypal})) if ref($attributes->{paypal}) eq 'HASH';
-    delete($attributes->{paypal});
-
-    $self->setup_sub_objects($self, $attributes, $sub_objects);
-    $self->set_attributes_from_hash($self, $attributes);
+    $self->set_attributes_from_hash($self, $attrs);
 }
 
 =head2 is_disbursed()
@@ -246,7 +253,7 @@ valid.
 
 sub is_disbursed {
     my $self = shift;
-    $self->disbursement_details->is_valid();
+    $self->disbursement_details && $self->disbursement_details->is_valid();
 };
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/WebService/Braintree/TransactionGateway.pm
+++ b/lib/WebService/Braintree/TransactionGateway.pm
@@ -3,9 +3,8 @@ package WebService::Braintree::TransactionGateway;
 use Moose;
 with 'WebService::Braintree::Role::MakeRequest';
 use Carp qw(confess);
-use WebService::Braintree::Util qw(validate_id);
+use WebService::Braintree::Util qw(validate_id to_instance_array);
 use WebService::Braintree::Validations qw(verify_params transaction_signature clone_transaction_signature transaction_search_results_signature);
-use WebService::Braintree::Util;
 
 has 'gateway' => (is => 'ro');
 

--- a/lib/WebService/Braintree/TransactionGateway.pm
+++ b/lib/WebService/Braintree/TransactionGateway.pm
@@ -59,8 +59,8 @@ sub search {
     my $response = $self->gateway->http->post("/transactions/advanced_search_ids", {search => $params});
     confess "DownForMaintenanceError" unless (verify_params($response, transaction_search_results_signature));
     return WebService::Braintree::ResourceCollection->new()->init($response, sub {
-                                                                      $self->fetch_transactions($search, shift);
-                                                                  });
+        $self->fetch_transactions($search, shift);
+    });
 }
 
 sub hold_in_escrow {
@@ -82,8 +82,8 @@ sub all {
     my $self = shift;
     my $response = $self->gateway->http->post("/transactions/advanced_search_ids");
     return WebService::Braintree::ResourceCollection->new()->init($response, sub {
-                                                                      $self->fetch_transactions(WebService::Braintree::TransactionSearch->new, shift);
-                                                                  });
+        $self->fetch_transactions(WebService::Braintree::TransactionSearch->new, shift);
+    });
 }
 
 sub fetch_transactions {

--- a/lib/WebService/Braintree/TransparentRedirectGateway.pm
+++ b/lib/WebService/Braintree/TransparentRedirectGateway.pm
@@ -5,7 +5,7 @@ with 'WebService::Braintree::Role::MakeRequest';
 
 use Carp qw(confess);
 use DateTime;
-use WebService::Braintree::Util;
+use WebService::Braintree::Util qw(hash_to_query_string);
 use WebService::Braintree::Digest qw(hexdigest);
 use WebService::Braintree::HTTP;
 use WebService::Braintree::Result;
@@ -33,7 +33,7 @@ sub create_customer_data {
     my ($self, $params) = @_;
     $self->requires($params, qw(redirect_url));
     $params->{'kind'} = 'create_customer';
-    return $self -> data_string($params);
+    return $self->data_string($params);
 }
 
 sub update_customer_data {
@@ -80,7 +80,7 @@ sub requires_type {
 
 sub time_string {
     my $dt = DateTime->now;
-    return $dt -> strftime("%Y%m%d%H%M%S");
+    return $dt->strftime("%Y%m%d%H%M%S");
 }
 
 sub data_string {

--- a/lib/WebService/Braintree/Util.pm
+++ b/lib/WebService/Braintree/Util.pm
@@ -14,7 +14,6 @@ our @EXPORT_OK = qw(
     is_arrayref is_hashref
 );
 
-#use Ref::Util qw(is_arrayref is_hashref);
 use URI::Query;
 
 # USED by ::TransparentRedirectGateway->build_tr_data and

--- a/lib/WebService/Braintree/Util.pm
+++ b/lib/WebService/Braintree/Util.pm
@@ -55,7 +55,6 @@ sub difference_arrays {
     return \@diff;
 }
 
-# USED in several places. UNCOVERED(!)
 sub to_instance_array {
     my ($attrs, $class) = @_;
     my @result = ();
@@ -69,7 +68,6 @@ sub to_instance_array {
     return \@result;
 }
 
-# USED all over the place, UNCOVERED?
 sub validate_id {
     my $id = shift;
 

--- a/lib/WebService/Braintree/Util.pm
+++ b/lib/WebService/Braintree/Util.pm
@@ -2,67 +2,65 @@ package WebService::Braintree::Util;
 
 use strict;
 
-use vars qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS );
-use URI::Query;
+use vars qw(@ISA @EXPORT_OK);
 use Exporter qw(import);
 our @ISA = qw(Exporter);
-our @EXPORT = qw(to_instance_array flatten is_hashref is_arrayref hash_to_query_string equal_arrays difference_arrays validate_id contains);
 
-sub flatten {
+our @EXPORT_OK = qw(
+    hash_to_query_string
+    to_instance_array
+    difference_arrays
+    validate_id
+    is_arrayref is_hashref
+);
+
+#use Ref::Util qw(is_arrayref is_hashref);
+use URI::Query;
+
+# USED by ::TransparentRedirectGateway->build_tr_data and
+#   ::TestHelper->simulate_form_post_for_tr
+sub hash_to_query_string {
+    my $query = URI::Query->new(__flatten(shift));
+    return $query->stringify();
+}
+
+# USED only by hash_to_query_string()
+sub __flatten {
     my($hash, $namespace) = @_;
     my %flat_hash = ();
     while (my ($key, $value) = each(%$hash)) {
         if (is_hashref($value)) {
-            my $sub_entries = flatten($value, add_namespace($key, $namespace));
+            my $sub_entries = __flatten($value, __add_namespace($key, $namespace));
             %flat_hash = (%flat_hash, %$sub_entries);
         } else {
-            $flat_hash{add_namespace($key, $namespace)} = $value;
+            $flat_hash{__add_namespace($key, $namespace)} = $value;
         }
     }
     return \%flat_hash;
 }
 
-sub add_namespace {
+# USED only by flatten()
+sub __add_namespace {
     my ($key, $namespace) = @_;
     return $key unless $namespace;
     return "${namespace}[${key}]";
 }
 
-sub is_hashref {
-    ref(shift) eq 'HASH';
-}
-
-sub is_arrayref {
-    ref(shift) eq 'ARRAY';
-}
-
-sub equal_arrays {
-    my ($first, $second) = @_;
-    return 0 unless @$first == @$second;
-    for (my $i = 0; $i < @$first; $i++) {
-        return 0 if $first->[$i] ne $second->[$i];
-    }
-    return 1;
-}
-
+# USED only in AdvancedSearchNodes in MultipleValuesNode->in() for validation
 sub difference_arrays {
     my ($array1, $array2) = @_;
     my @diff;
     foreach my $element (@$array1) {
-        push(@diff, $element) unless contains($element, $array2);
+        push(@diff, $element) unless grep { $element eq $_ } @$array2;
     }
     return \@diff;
 }
 
-sub hash_to_query_string {
-    my $query = URI::Query -> new(flatten(shift));
-    return $query->stringify();
-}
-
+# USED in several places. UNCOVERED(!)
 sub to_instance_array {
     my ($attrs, $class) = @_;
     my @result = ();
-    if (ref $attrs ne "ARRAY") {
+    if (! is_arrayref($attrs)) {
         push(@result, $class->new($attrs));
     } else {
         for (@$attrs) {
@@ -71,25 +69,23 @@ sub to_instance_array {
     }
     return \@result;
 }
-sub trim {
-    my $string = shift;
-    $string =~ s/^\s+//;
-    $string =~ s/\s+$//;
-    return $string;
-}
 
+# USED all over the place, UNCOVERED?
 sub validate_id {
     my $id = shift;
-    return 0 if(!defined($id) || trim($id) eq "");
+
+    return if ! defined($id);
+    return if $id !~ /\S/;
+
     return 1;
 }
 
-sub contains {
-    my ($element, $array) = @_;
-    for (@$array) {
-        return 1 if $_ eq $element;
-    }
-    return 0;
+sub is_hashref {
+    ref(shift) eq 'HASH';
+}
+
+sub is_arrayref {
+    ref(shift) eq 'ARRAY';
 }
 
 1;

--- a/lib/WebService/Braintree/ValidationErrorCollection.pm
+++ b/lib/WebService/Braintree/ValidationErrorCollection.pm
@@ -11,7 +11,6 @@ This class represents a collection of validation errors.
 =cut
 
 use Moose;
-use WebService::Braintree::Util;
 use WebService::Braintree::ValidationError;
 
 =head1 CLASS METHODS

--- a/lib/WebService/Braintree/Validations.pm
+++ b/lib/WebService/Braintree/Validations.pm
@@ -2,11 +2,24 @@ package WebService::Braintree::Validations;
 
 use strict;
 
-use WebService::Braintree::Util;
-use vars qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS );
+use Ref::Util qw(is_hashref);
+
+use vars qw(@ISA @EXPORT_OK);
 use Exporter;
 our @ISA = qw(Exporter);
-our @EXPORT_OK = qw(verify_params address_signature client_token_signature_with_customer_id client_token_signature_without_customer_id credit_card_signature customer_signature transaction_signature clone_transaction_signature merchant_account_signature transaction_search_results_signature);
+
+our @EXPORT_OK = qw(
+    verify_params
+    address_signature
+    client_token_signature_with_customer_id
+    client_token_signature_without_customer_id
+    credit_card_signature
+    customer_signature
+    transaction_signature
+    clone_transaction_signature
+    merchant_account_signature
+    transaction_search_results_signature
+);
 
 sub verify_params {
     my ($params, $white_list) = @_;

--- a/lib/WebService/Braintree/Validations.pm
+++ b/lib/WebService/Braintree/Validations.pm
@@ -2,7 +2,7 @@ package WebService::Braintree::Validations;
 
 use strict;
 
-use Ref::Util qw(is_hashref);
+use WebService::Braintree::Util qw(is_hashref);
 
 use vars qw(@ISA @EXPORT_OK);
 use Exporter;

--- a/lib/WebService/Braintree/WebhookNotification.pm
+++ b/lib/WebService/Braintree/WebhookNotification.pm
@@ -1,5 +1,7 @@
 package WebService::Braintree::WebhookNotification;
 
+use WebService::Braintree::Util qw(is_hashref);
+
 =head1 NAME
 
 WebService::Braintree::WebhookNotification
@@ -130,47 +132,40 @@ be a string.
 
 has message => (is => 'rw');
 
-
 sub BUILD {
     my ($self, $attributes) = @_;
 
     my $wrapper_node = $attributes->{subject};
 
-    if (ref($wrapper_node->{api_error_response}) eq 'HASH') {
+    if (is_hashref($wrapper_node->{api_error_response})) {
         $wrapper_node = $wrapper_node->{api_error_response};
     }
 
-    if (ref($wrapper_node->{subscription}) eq 'HASH') {
-
+    if (is_hashref($wrapper_node->{subscription})) {
         $self->subscription(WebService::Braintree::Subscription->new($wrapper_node->{subscription}));
     }
 
-    if (ref($wrapper_node->{merchant_account}) eq 'HASH') {
-
+    if (is_hashref($wrapper_node->{merchant_account})) {
         $self->merchant_account(WebService::Braintree::MerchantAccount->new($wrapper_node->{merchant_account}));
     }
 
-    if (ref($wrapper_node->{disbursement}) eq 'HASH') {
-
+    if (is_hashref($wrapper_node->{disbursement})) {
         $self->disbursement(WebService::Braintree::Disbursement->new($wrapper_node->{disbursement}));
     }
 
-    if (ref($wrapper_node->{transaction}) eq 'HASH') {
-
+    if (is_hashref($wrapper_node->{transaction})) {
         $self->transaction(WebService::Braintree::Transaction->new($wrapper_node->{transaction}));
     }
 
-    if (ref($wrapper_node->{partner_merchant}) eq 'HASH') {
-
+    if (is_hashref($wrapper_node->{partner_merchant})) {
         $self->partner_merchant(WebService::Braintree::PartnerMerchant->new($wrapper_node->{partner_merchant}));
     }
 
-    if (ref($wrapper_node->{dispute}) eq 'HASH') {
-
+    if (is_hashref($wrapper_node->{dispute})) {
         $self->dispute(WebService::Braintree::Dispute->new($wrapper_node->{dispute}));
     }
 
-    if (ref($wrapper_node->{errors}) eq 'HASH') {
+    if (is_hashref($wrapper_node->{errors})) {
         $self->errors(WebService::Braintree::ValidationErrorCollection->new($wrapper_node->{errors}));
         $self->message($wrapper_node->{message});
     }

--- a/lib/WebService/Braintree/WebhookNotificationGateway.pm
+++ b/lib/WebService/Braintree/WebhookNotificationGateway.pm
@@ -1,17 +1,19 @@
 package WebService::Braintree::WebhookNotificationGateway;
 
-
 use MIME::Base64;
 use WebService::Braintree::Digest qw(hexdigest);
 use WebService::Braintree::Xml qw(xml_to_hash);
 use Carp qw(confess);
+
 use Moose;
 
 has 'gateway' => (is => 'ro');
 
 sub parse {
     my ($self, $signature, $payload) = @_;
+
     $self->_validate_signature($signature, $payload);
+
     my $xml_payload = decode_base64($payload);
     my $attributes = xml_to_hash($xml_payload);
 
@@ -20,6 +22,7 @@ sub parse {
 
 sub _matching_signature {
     my ($self, $signature, $payload) = @_;
+
     foreach my $signature_pair (split("&", $signature)) {
         my @components = split("\\|", $signature_pair);
 
@@ -27,21 +30,30 @@ sub _matching_signature {
             return $components[1];
         }
     }
+
+    # Definitively return undef if nothing is found.
+    return;
 }
 
 sub _validate_signature {
     my ($self, $signature, $payload) = @_;
+
     my $matching_signature = $self->_matching_signature($signature, $payload);
-    if (defined($matching_signature) && $matching_signature ne hexdigest($self->gateway->config->private_key, $payload)) {
+
+    if (!defined($matching_signature) || $matching_signature ne hexdigest($self->gateway->config->private_key, $payload)) {
         confess "InvalidSignature";
     }
+
+    return 1;
 }
 
 sub verify {
     my ($self, $challenge) = @_;
+
     if ($challenge !~ /^[a-f0-9]{20,32}$/) {
         confess "InvalidChallenge";
     }
+
     return $self->gateway->config->public_key . "|" . hexdigest($self->gateway->config->private_key, $challenge);
 }
 

--- a/lib/WebService/Braintree/Xml.pm
+++ b/lib/WebService/Braintree/Xml.pm
@@ -69,11 +69,11 @@ sub scrubbed {
     my $tree = shift;
     if (is_hashref($tree)) {
         return collect_from_hash($tree);
-    }
-    if (is_arrayref($tree)) {
+    } elsif (is_arrayref($tree)) {
         return collect_from_array($tree);
+    } else {
+      return $tree;
     }
-    return $tree;
 }
 
 sub collect_from_array {

--- a/lib/WebService/Braintree/Xml.pm
+++ b/lib/WebService/Braintree/Xml.pm
@@ -61,8 +61,7 @@ sub build_node {
 
 sub xml_to_hash {
     my $return = XMLin(shift, KeyAttr => [], KeepRoot => 1);
-    my $scrubbed = scrubbed($return);
-    return $scrubbed;
+    return scrubbed($return);
 }
 
 sub scrubbed {
@@ -72,7 +71,7 @@ sub scrubbed {
     } elsif (is_arrayref($tree)) {
         return collect_from_array($tree);
     } else {
-      return $tree;
+        return $tree;
     }
 }
 
@@ -90,11 +89,11 @@ sub collect_from_hash {
     my $new_hash = {};
 
     my %types = (
-        'array' => \&array,
-        'boolean' => \&boolean,
-        'integer' => \&integer,
-        'datetime' => \&datetime,
-        'date' => \&date
+        array => \&array,
+        boolean => \&boolean,
+        integer => \&integer,
+        datetime => \&datetime,
+        date => \&date
     );
 
     foreach my $type (keys %types) {
@@ -146,29 +145,21 @@ sub array {
 
     delete $tree->{type};
     my $subtree = (values %$tree)[0];
-    if (ref $subtree eq 'HASH') {
+    if (is_hashref($subtree)) {
         return [scrubbed($subtree)];
-    } elsif (ref $subtree eq 'ARRAY') {
-        return scrubbed(force_array($subtree));
+    } elsif (is_arrayref($subtree)) {
+        return scrubbed($subtree);
     } elsif (defined($subtree)) {
         return [$subtree];
     } else {
         return [];
     }
-
 }
-
 
 sub sub_dashes {
     my $string = shift;
     $string =~ s/-/_/g;
     return $string;
-}
-
-sub force_array {
-    my $subtree = shift;
-    return $subtree if(is_arrayref($subtree));
-    return [$subtree];
 }
 
 1;

--- a/lib/WebService/Braintree/Xml.pm
+++ b/lib/WebService/Braintree/Xml.pm
@@ -2,14 +2,15 @@ package WebService::Braintree::Xml;
 
 use strict;
 
-use XML::Simple;
-use vars qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS );
+use vars qw(@ISA @EXPORT_OK);
 use Exporter;
 our @ISA = qw(Exporter);
-our @EXPORT = qw(hash_to_xml xml_to_hash array collect_from_array);
-our @EXPORT_OK = qw();
-use WebService::Braintree::Util;
+our @EXPORT_OK = qw(hash_to_xml xml_to_hash);
+
+use XML::Simple;
+
 use DateTime::Format::Atom;
+use WebService::Braintree::Util qw(is_arrayref is_hashref);
 use XML::LibXML;
 
 sub hash_to_xml {

--- a/run_tests
+++ b/run_tests
@@ -8,6 +8,10 @@ cd $mydir
 
 container="robkinyon/webservice-braintree-test"
 # Broken: 5.12
+# 5.10 doesn't build
+#    Configure failed for Dist-Zilla-6.010.
+# 5.18 doesn't build
+#     Installing DateTime::Format::Atom failed.
 all_versions="5.10 5.14 5.16 5.18 5.20 5.22 5.24"
 
 # This is to handle GitBash's auto-mangling of path names when interacting

--- a/t/configuration.t
+++ b/t/configuration.t
@@ -1,9 +1,10 @@
 # vim: sw=4 ts=4 ft=perl
+use strict;
+
+use lib qw(lib t/lib);
 
 use Test::More;
 use Test::Warn;
-
-use lib qw(lib t/lib);
 
 use WebService::Braintree;
 
@@ -16,13 +17,94 @@ $config->private_key("integration_private_key");
 
 $config = WebService::Braintree->configuration;
 
-subtest "Configuration instance" => sub {
-    is $config->environment, "sandbox", "Config environment";
-    is $config->public_key , "integration_public_key", "Config public key";
-    is $config->merchant_id, "integration_merchant_id", "Config merch id";
-    is $config->private_key, "integration_private_key", "Config private key";
-    is $config->base_merchant_path, "/merchants/integration_merchant_id", "generates base merchant path based on merchant id";
+subtest 'server()' => sub {
+    my %choices = (
+        development => 'localhost',
+        integration => 'localhost',
+        sandbox     => 'api.sandbox.braintreegateway.com',
+        qa          => 'qa-master.braintreegateway.com',
+        production  => 'api.braintreegateway.com',
+    );
+
+    while (my ($env, $url) = each %choices) {
+        $config->environment($env);
+        is $config->server, $url, "server() in $env is correct";
+    }
 };
+
+subtest 'auth_url()' => sub {
+    my %choices = (
+        development => 'http://auth.venmo.dev:9292',
+        integration => 'http://auth.venmo.dev:9292',
+        sandbox     => 'https://auth.sandbox.venmo.com',
+        qa          => 'https://auth.qa.venmo.com',
+        production  => 'https://auth.venmo.com',
+    );
+
+    while (my ($env, $url) = each %choices) {
+        $config->environment($env);
+        is $config->auth_url, $url, "auth_url() in $env is correct";
+    }
+};
+
+subtest 'ssl_enabled()' => sub {
+    my %choices = (
+        development => !1,
+        integration => !1,
+        sandbox     => !!1,
+        qa          => !!1,
+        production  => !!1,
+    );
+
+    while (my ($env, $truth) = each %choices) {
+        $config->environment($env);
+        if ($truth) {
+            ok $config->ssl_enabled, "ssl_enabled() in $env is correct";
+        }
+        else {
+            ok !$config->ssl_enabled, "ssl_enabled() in $env is correct";
+        }
+    }
+};
+
+subtest 'protocol()' => sub {
+    my %choices = (
+        development => 'http',
+        integration => 'http',
+        sandbox     => 'https',
+        qa          => 'https',
+        production  => 'https',
+    );
+
+    while (my ($env, $protocol) = each %choices) {
+        $config->environment($env);
+        is $config->protocol, $protocol, "protocol() in $env is correct";
+    }
+};
+
+subtest 'port()' => sub {
+    for my $env (qw(development integration)) {
+        subtest "in $env" => sub {
+            $config->environment($env);
+
+            is $config->port, '3000', "Inside $env, port is 3000 by default";
+
+            local $ENV{GATEWAY_PORT} = 9988;
+            is $config->port, '9988', "Inside $env, respect GATEWAY_PORT";
+        };
+    }
+
+    subtest 'outside development' => sub {
+        $config->environment('production');
+        is $config->port, '443', 'Outside development, port is 443';
+    };
+};
+
+subtest 'api_version()' => sub {
+    is $config->api_version, 4;
+};
+
+
 
 my @examples = (
     ['sandbox', "https://api.sandbox.braintreegateway.com:443/merchants/integration_merchant_id"],
@@ -36,34 +118,10 @@ foreach (@examples) {
     is $config->base_merchant_url, $url, "$environment base merchant url";
 }
 
-my @examples = (
-    ['development', "http://auth.venmo.dev:9292"],
-    ['sandbox', "https://auth.sandbox.venmo.com"],
-    ['production', "https://auth.venmo.com"],
-    ['qa', "https://auth.qa.venmo.com"]
-);
-
-foreach (@examples) {
-    my($environment, $url) = @$_;
-    $config->environment($environment);
-    is $config->auth_url, $url, "$environment auth_url";
-}
-subtest "setting configuration attributes with hash constructor" => sub {
-    my $configuration = WebService::Braintree::Configuration->new(
-        merchant_id => "integration_merchant_id",
-        public_key => "integration_public_key",
-        private_key => "integration_private_key",
-        environment => "development"
-    );
-
-    is $configuration->merchant_id, "integration_merchant_id";
-    is $configuration->public_key, "integration_public_key";
-    is $configuration->private_key, "integration_private_key";
-    is $configuration->environment, "development";
-};
-
-warning_is {$config->environment("not_valid")} "Assigned invalid value to WebService::Braintree::Configuration::environment",
-    "Bad environment gives a warning";
+warning_is {
+    $config->environment('not_valid')
+} 'Assigned invalid value to WebService::Braintree::Configuration::environment',
+'Bad environment gives a warning';
 
 $config->environment("integration");
 $ENV{'GATEWAY_PORT'} = "8104";

--- a/t/inflate_xml.t
+++ b/t/inflate_xml.t
@@ -5,7 +5,7 @@ use Test::More;
 use lib qw(lib t/lib);
 
 use WebService::Braintree;
-use WebService::Braintree::Xml;
+use WebService::Braintree::Xml qw(xml_to_hash);
 use WebService::Braintree::TestHelper;
 
 subtest "should survive some deep parsing" => sub {

--- a/t/lib/WebService/Braintree/MockHTTP.pm
+++ b/t/lib/WebService/Braintree/MockHTTP.pm
@@ -4,10 +4,10 @@ package WebService::Braintree::MockHTTP;
 
 use Moose;
 
-has method => (is => 'rw' );
-has result => ( is => 'rw' );
-has path => ( is => 'rw');
-has params => ( is => 'rw' );
+has method => (is => 'rw');
+has result => (is => 'rw');
+has path => (is => 'rw');
+has params => (is => 'rw');
 
 sub post {
     my $self = shift;
@@ -21,7 +21,7 @@ sub put {
     my $self = shift;
     $self->path(shift);
     $self->params(shift);
-    $self->method("put");
+    $self->method('put');
     return $self->result;
 }
 
@@ -29,7 +29,7 @@ sub get {
     my $self = shift;
     $self->path(shift);
     $self->params(shift);
-    $self->method("get");
+    $self->method('get');
     return $self->result;
 }
 
@@ -37,7 +37,7 @@ sub delete {
     my $self = shift;
     $self->path(shift);
     $self->params(shift);
-    $self->method("delete");
+    $self->method('delete');
     return $self->result;
 }
 

--- a/t/lib/WebService/Braintree/TestHelper.pm
+++ b/t/lib/WebService/Braintree/TestHelper.pm
@@ -16,6 +16,8 @@ use LWP::UserAgent;
 use MIME::Base64;
 use Time::HiRes qw(gettimeofday);
 use Try::Tiny;
+use WebService::Braintree::Util qw(hash_to_query_string);
+use DateTime::Format::Strptime;
 use URI::Escape;
 
 use WebService::Braintree;

--- a/t/util.t
+++ b/t/util.t
@@ -4,7 +4,11 @@ use Test::More;
 
 use lib qw(lib t/lib);
 
-use WebService::Braintree::Util qw(difference_arrays);
+use WebService::Braintree::Util qw(
+    difference_arrays
+    to_instance_array
+    validate_id
+);
 use WebService::Braintree::TestHelper;
 
 use Test::Deep;
@@ -25,6 +29,43 @@ subtest "difference arrays" => sub {
     cmp_deeply(difference_arrays(['a', 'b'], ['a']), ['b']);
     cmp_deeply(difference_arrays(['a', 'b'], ['b']), ['a']);
     cmp_deeply(difference_arrays(['a'], ['a', 'b']), []);
+};
+
+{
+    package Testing::Object;
+
+    sub new {
+        my $class = shift;
+        my ($param) = @_;
+
+        my $self = {};
+        $self->{param} = $param;
+        return bless $self, $class;
+    }
+}
+
+subtest to_instance_array => sub {
+    subtest 'not arrayref of parameters' => sub {
+        my $params = 'a';
+        my $objs = to_instance_array($params, 'Testing::Object');
+        is(scalar(@$objs), 1, 'one item in the array');
+        is($objs->[0]{param}, $params, "... and the value was preserved");
+    };
+
+    subtest 'arrayref of parameters' => sub {
+        my $params = [ 'a', 'b', 'c' ];
+        my $objs = to_instance_array($params, 'Testing::Object');
+        is(scalar(@$objs), scalar(@$params), 'right number of items');
+        cmp_deeply([map { $_->{param} } @$objs], $params, "... and the values were preserved");
+    };
+};
+
+subtest validate_id => sub {
+    ok(!validate_id(), 'validate_id of nothing is false');
+    ok(!validate_id(undef), 'validate_id of undefined is false');
+    ok(!validate_id(""), 'validate_id of empty is false');
+    ok(!validate_id(" "), 'validate_id of space is false');
+    ok(validate_id("1"), 'validate_id of anything else is true');
 };
 
 done_testing();

--- a/t/util.t
+++ b/t/util.t
@@ -4,40 +4,27 @@ use Test::More;
 
 use lib qw(lib t/lib);
 
-use WebService::Braintree::Util;
+use WebService::Braintree::Util qw(difference_arrays);
 use WebService::Braintree::TestHelper;
 
+use Test::Deep;
+
+# This is an internal method only. It is NOT exported.
 subtest "Flatten Hashes" => sub {
-    is_deeply(flatten({}), {}, "empty hash");
-    is_deeply(flatten({"a" => "1"}), {"a" => "1"}, "One element.");
-    is_deeply(flatten({"a" => {"b" => "1"}}), {"a[b]" => "1"}, "One namespace");
-    is_deeply(flatten({"a" => {"b" => "1"}, "a2" => {"q" => "r"}}), {"a[b]" => "1", "a2[q]" => "r"}, "Two horizontal namespace");
-    is_deeply(flatten({"a" => {"b" => {"c" => "1"}}}), {"a[b][c]" => "1"}, "Vertical merging");
-};
+    my $flatten = WebService::Braintree::Util->can('__flatten');
 
-subtest "equal arrays" => sub {
-    ok(equal_arrays(['a'], ['a']));
-    ok(equal_arrays(['a', 'b'], ['a', 'b']));
-    not_ok(equal_arrays(['a'], ['b']));
-    not_ok(equal_arrays(['a', 'b'], ['b']));
-
-    my $hash = { 'a' => 'b' };
-    ok(equal_arrays([ keys %$hash ], ['a']));
+    is_deeply($flatten->({}), {}, "empty hash");
+    is_deeply($flatten->({"a" => "1"}), {"a" => "1"}, "One element.");
+    is_deeply($flatten->({"a" => {"b" => "1"}}), {"a[b]" => "1"}, "One namespace");
+    is_deeply($flatten->({"a" => {"b" => "1"}, "a2" => {"q" => "r"}}), {"a[b]" => "1", "a2[q]" => "r"}, "Two horizontal namespace");
+    is_deeply($flatten->({"a" => {"b" => {"c" => "1"}}}), {"a[b][c]" => "1"}, "Vertical merging");
 };
 
 subtest "difference arrays" => sub {
-    ok(equal_arrays(difference_arrays(['a', 'b'], ['a', 'b']), []));
-    is_deeply(difference_arrays(['a', 'b'], ['a']), ['b']);
-    ok(equal_arrays(difference_arrays(['a', 'b'], ['b']), ['a']));
-    ok(equal_arrays(difference_arrays(['a'], ['a', 'b']), []));
-};
-
-subtest "is_hashref" => sub {
-    my $dt = DateTime->now();
-    my %true_hash = (key => "value");
-    not_ok is_hashref($dt);
-    ok is_hashref({key => "value"});
-    ok is_hashref(\%true_hash);
+    cmp_deeply(difference_arrays(['a', 'b'], ['a', 'b']), []);
+    cmp_deeply(difference_arrays(['a', 'b'], ['a']), ['b']);
+    cmp_deeply(difference_arrays(['a', 'b'], ['b']), ['a']);
+    cmp_deeply(difference_arrays(['a'], ['a', 'b']), []);
 };
 
 done_testing();

--- a/t/webhook_notification.t
+++ b/t/webhook_notification.t
@@ -147,7 +147,7 @@ subtest 'sample_notification builds a sample notification for dispute won', sub 
     is $webhook_notification->dispute->id, 'my_id';
 };
 
-subtest 'sample_notification builds a sample notification for disbursement', sub {
+subtest 'sample_notification builds a sample notification for disbursement exception', sub {
     my ($signature, $payload) = WebService::Braintree::WebhookTesting->sample_notification(
         WebService::Braintree::WebhookNotification::Kind::DisbursementException,
         'my_id',
@@ -163,7 +163,7 @@ subtest 'sample_notification builds a sample notification for disbursement', sub
     is $webhook_notification->disbursement->merchant_account->id, 'merchant_account_token';
 };
 
-subtest 'sample_notification builds a sample notification for disbursement exception', sub {
+subtest 'sample_notification builds a sample notification for disbursement', sub {
     my ($signature, $payload) = WebService::Braintree::WebhookTesting->sample_notification(
         WebService::Braintree::WebhookNotification::Kind::Disbursement,
         'my_id',

--- a/t/xml.t
+++ b/t/xml.t
@@ -4,7 +4,7 @@ use Test::More;
 
 use lib qw(lib t/lib);
 
-use WebService::Braintree::Xml;
+use WebService::Braintree::Xml qw(xml_to_hash);
 use WebService::Braintree::TestHelper;
 
 subtest "simple parsing" => sub {
@@ -13,10 +13,13 @@ subtest "simple parsing" => sub {
 };
 
 subtest "folding array" => sub {
-    is_deeply array({transaction =>[ {id => 1}, {id  => 2}]}), [{id => 1}, {id  => 2}];
-    is_deeply array({type => "array", transaction =>[ {id => 1}, {id  => 2}] }), [{id => 1}, {id  => 2}];
-    is_deeply array({transaction => {id => 1}}), [{id => 1}];
-    is_deeply array({type => "array", transaction => {id => 1}}), [{id => 1}];
+    # This is an unexported method.
+    my $array_method = WebService::Braintree::Xml->can('array');
+
+    is_deeply $array_method->({transaction =>[ {id => 1}, {id  => 2}]}), [{id => 1}, {id  => 2}];
+    is_deeply $array_method->({type => "array", transaction =>[ {id => 1}, {id  => 2}] }), [{id => 1}, {id  => 2}];
+    is_deeply $array_method->({transaction => {id => 1}}), [{id => 1}];
+    is_deeply $array_method->({type => "array", transaction => {id => 1}}), [{id => 1}];
 };
 
 subtest "type = array with one sub-element" => sub {

--- a/t/xml_builder.t
+++ b/t/xml_builder.t
@@ -8,13 +8,19 @@ use WebService::Braintree::Xml qw(hash_to_xml xml_to_hash);
 use WebService::Braintree::TestHelper;
 
 sub check_round_trip {
-    my $data = shift;
-    my $print_xml = shift;
+    my ($data, $print_xml) = @_;
+
     my $xml = hash_to_xml($data);
+    note($xml) if $print_xml;
+
     is_deeply xml_to_hash($xml), $data
 }
 
 subtest "generated simple xml" => sub {
+    TODO: {
+        local $TODO = "undef doesn't flip back properly";
+        check_round_trip({key => undef}, 1);
+    }
     check_round_trip({key => "value"});
     check_round_trip({key => {subkey => "value2", subkey2 => "value3"}});
     check_round_trip({key => {subkey => {subsubkey => "value3"}}});
@@ -24,15 +30,15 @@ subtest "generated simple xml" => sub {
 
 subtest "generate arrays correctly" => sub {
     my $actual = hash_to_xml({search => {ids => [1, 2, 3]}});
-    my $expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    my $expected = '<?xml version="1.0" encoding="UTF-8"?>
 <search>
-  <ids type=\"array\">
+  <ids type="array">
     <item>1</item>
     <item>2</item>
     <item>3</item>
   </ids>
 </search>
-";
+';
     is $actual, $expected;
 };
 

--- a/t/xml_builder.t
+++ b/t/xml_builder.t
@@ -4,7 +4,7 @@ use Test::More;
 
 use lib qw(lib t/lib);
 
-use WebService::Braintree::Xml;
+use WebService::Braintree::Xml qw(hash_to_xml xml_to_hash);
 use WebService::Braintree::TestHelper;
 
 sub check_round_trip {

--- a/xt/sandbox/credit_card_verification_search.t
+++ b/xt/sandbox/credit_card_verification_search.t
@@ -43,7 +43,6 @@ subtest "Searches text and partial match and equality fields" => sub {
     is $search_results->first->credit_card->{'last_4'}, "1115";
 };
 
-=pod
 subtest "Searches multiple value fields" => sub {
     my $visa_credit_card_params = {
         customer_id => $customer_create->customer->id,
@@ -146,6 +145,5 @@ subtest "Searches range fields" => sub {
 
     is $search_results->maximum_size, 0;
 };
-=cut
 
 done_testing();

--- a/xt/sandbox/credit_card_verification_search.t
+++ b/xt/sandbox/credit_card_verification_search.t
@@ -41,9 +41,9 @@ subtest "Searches text and partial match and equality fields" => sub {
     is $search_results->first->credit_card->{'expiration_month'}, "12";
     is $search_results->first->credit_card->{'bin'}, "400011";
     is $search_results->first->credit_card->{'last_4'}, "1115";
-
 };
 
+=pod
 subtest "Searches multiple value fields" => sub {
     my $visa_credit_card_params = {
         customer_id => $customer_create->customer->id,
@@ -146,5 +146,6 @@ subtest "Searches range fields" => sub {
 
     is $search_results->maximum_size, 0;
 };
+=cut
 
 done_testing();

--- a/xt/sandbox/customer_search.t
+++ b/xt/sandbox/customer_search.t
@@ -129,7 +129,7 @@ sub create_customer {
         first_name => "NotInFaker",
         last_name => "O'Toole",
         company => $company,
-        email => "timmy\@example.com",
+        email => 'timmy@example.com',
         fax => "3145551234",
         phone => "5551231234",
         website => "http://example.com",
@@ -147,8 +147,8 @@ sub create_customer {
                 region => "Illinois",
                 postal_code => "60622",
                 country_name => "United States of America",
-            }
-        }
+            },
+        },
     };
     return WebService::Braintree::Customer->create($customer_attributes);
 }

--- a/xt/sandbox/transaction_search.t
+++ b/xt/sandbox/transaction_search.t
@@ -195,6 +195,8 @@ subtest "source - multiple value field" => sub {
     });
 
     ok grep { $_ eq $find->id } @{$search_result->ids};
+
+    # There are >5300 transactions. This generates N+1 API calls.
     #my @results = ();
     #$search_result->each(sub { push(@results, shift->id); });
     #ok grep { $_ eq $find->id } @results;

--- a/xt/sandbox/transaction_search.t
+++ b/xt/sandbox/transaction_search.t
@@ -78,9 +78,9 @@ subtest "results 'first'" => sub {
         my $search_result = perform_search(Transaction => $criteria);
 
         is scalar @{$search_result->ids}, 2;
-        ok contains($sale1->transaction->id, $search_result->ids);
-        ok contains($sale2->transaction->id, $search_result->ids);
-        ok contains($search_result->first->id, [$sale2->transaction->id, $sale1->transaction->id]);
+        ok grep { $_ eq $sale1->transaction->id } @{$search_result->ids};
+        ok grep { $_ eq $sale2->transaction->id } @{$search_result->ids};
+        ok grep { $_ eq $search_result->first->id } ($sale2->transaction->id, $sale1->transaction->id);
         is $search_result->first->amount, '5.00';
     };
 };
@@ -117,8 +117,8 @@ subtest "result 'each'" => sub {
         my @results = ();
         $search_result->each(sub { push(@results, shift->id); });
 
-        ok contains($sale1->transaction->id, \@results);
-        ok contains($sale2->transaction->id, \@results);
+        ok grep { $_ eq $sale1->transaction->id } @results;
+        ok grep { $_ eq $sale2->transaction->id } @results;
         is scalar(@results), 2;
     };
 };
@@ -134,10 +134,10 @@ subtest "credit_card_card_type - multiple value field" => sub {
         $search->credit_card_card_type->is(WebService::Braintree::CreditCard::CardType::MasterCard);
     });
 
-    ok contains($find->id, $search_result->ids);
+    ok grep { $_ eq $find->id } @{$search_result->ids};
     #my @results = ();
     #$search_result->each(sub { push(@results, shift->id); });
-    #ok contains($find->id, \@results);
+    #ok grep { $_ eq $find->id } @results;
 };
 
 subtest "credit_card_card_type - multiple value field - passing invalid credit_card_card_type" => sub {
@@ -169,10 +169,10 @@ subtest "status - multiple value field" => sub {
         $search->status->is($find->status);
     });
 
-    ok contains($find->id, $search_result->ids);
+    ok grep { $_ eq $find->id } @{$search_result->ids};
     #my @results = ();
     #$search_result->each(sub { push(@results, shift->id); });
-    #ok contains($find->id, \@results);
+    #ok grep { $_ eq $find->id } @results;
 };
 
 subtest "source - multiple value field - passing invalid source" => sub {
@@ -194,10 +194,10 @@ subtest "source - multiple value field" => sub {
         $search->source->is(WebService::Braintree::Transaction::Source::Api);
     });
 
-    ok contains($find->id, $search_result->ids);
+    ok grep { $_ eq $find->id } @{$search_result->ids};
     #my @results = ();
     #$search_result->each(sub { push(@results, shift->id); });
-    #ok contains($find->id, \@results);
+    #ok grep { $_ eq $find->id } @results;
 };
 
 subtest "type - multiple value field - passing invalid type" => sub {
@@ -219,10 +219,10 @@ subtest "type - multiple value field" => sub {
         $search->type->is(WebService::Braintree::Transaction::Type::Sale);
     });
 
-    ok contains($find->id, $search_result->ids);
+    ok grep { $_ eq $find->id } @{$search_result->ids};
     #my @results = ();
     #$search_result->each(sub { push(@results, shift->id); });
-    #ok contains($find->id, \@results);
+    #ok grep { $_ eq $find->id } @results;
 };
 
 subtest "credit card number - partial match" => sub {
@@ -236,7 +236,7 @@ subtest "credit card number - partial match" => sub {
         $search->credit_card_number->ends_with($find->credit_card->last_4);
     });
 
-    ok contains($find->id, $search_result->ids);
+    ok grep { $_ eq $find->id } @{$search_result->ids};
 };
 
 subtest "amount - range" => sub {
@@ -259,8 +259,8 @@ subtest "amount - range" => sub {
         $search->amount->min("4.50");
     });
 
-    ok contains($find->id, $search_result->ids);
-    not_ok contains($sale2->id, $search_result->ids);
+    ok grep { $_ eq $find->id } @{$search_result->ids};
+    not_ok grep { $_ eq $sale2->id } @{$search_result->ids};
 };
 
 TODO: {
@@ -274,7 +274,7 @@ TODO: {
             $search->disbursement_date->min(WebService::Braintree::TestHelper::parse_datetime("2012-01-01 00:00:00"));
         });
 
-        ok contains("deposittransaction", $search_result->ids);
+        ok grep { $_ eq "deposittransaction" } @{$search_result->ids};
         is scalar @{$search_result->ids}, 1;
     };
 
@@ -298,7 +298,7 @@ TODO: {
             $search->dispute_date->min(WebService::Braintree::TestHelper::parse_datetime("2014-03-01 00:00:00"));
         });
 
-        ok contains("disputedtransaction", $search_result->ids);
+        ok grep { $_ eq "disputedtransaction" } @{$search_result->ids};
         is scalar @{$search_result->ids}, 1;
     };
 
@@ -309,7 +309,7 @@ TODO: {
             $search->dispute_date->is(WebService::Braintree::TestHelper::parse_datetime("2014-03-01 00:00:00"));
         });
 
-        ok contains("disputedtransaction", $search_result->ids);
+        ok grep { $_ eq "disputedtransaction" } @{$search_result->ids};
         is scalar @{$search_result->ids}, 1;
     };
 }


### PR DESCRIPTION
This is the first PR with actual logic changes, among other things.

Improvements:
1. ::Configuration is significantly cleaned up
1. All uses of ::Util are now explicitly imported.
1. All `ref` checks now use the `is_Xref()` functions from ::Util
1. All checks that duplicate `validate_id()` now use that function
1. The `contains()` function has been removed and replaced with `grep`
1. Usage of methods in ::Util are documented. Most are only used in 1 place.
1. A `build_sub_object()` method has been added to ::Result for improved readability
1. Coverage of several key modules has been increased to 100

Logic changes:
1. `::Result::maximum_size()` no longer throws an exception if there are no ids.
1. `::WebhookNotificationGateway::_validate_signature()` now properly throws an exception if there is no signature pair.
1. Removed the useless `::Xml::force_array` as it could do nothing