### PR TITLE
Enable strictures

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -48,6 +48,7 @@ Scalar::Util = 0
 URI::Query = 0
 XML::Simple = 0
 JSON = 0
+strictures = 0
 
 [Prereqs / TestRequires]
 Test::More = 0.98

--- a/lib/WebService/Braintree.pm
+++ b/lib/WebService/Braintree.pm
@@ -1,7 +1,8 @@
 package WebService::Braintree;
 
-use strict;
-use warnings;
+use 5.010_001;
+use strictures 1;
+
 use WebService::Braintree::Address;
 use WebService::Braintree::AdvancedSearchFields;
 use WebService::Braintree::AdvancedSearchNodes;

--- a/lib/WebService/Braintree/Address.pm
+++ b/lib/WebService/Braintree/Address.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::Address;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::Address

--- a/lib/WebService/Braintree/AddressGateway.pm
+++ b/lib/WebService/Braintree/AddressGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::AddressGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 with 'WebService::Braintree::Role::MakeRequest';
 

--- a/lib/WebService/Braintree/AdvancedSearch.pm
+++ b/lib/WebService/Braintree/AdvancedSearch.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::AdvancedSearch;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 sub search_to_hash {
     my ($self, $search) = @_;

--- a/lib/WebService/Braintree/AdvancedSearchFields.pm
+++ b/lib/WebService/Braintree/AdvancedSearchFields.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::AdvancedSearchFields;
 
+use 5.010_001;
+use strictures 1;
+
 use Carp;
 use Moose;
 

--- a/lib/WebService/Braintree/AdvancedSearchFields.pm
+++ b/lib/WebService/Braintree/AdvancedSearchFields.pm
@@ -13,36 +13,36 @@ sub field {
 sub is {
     my ($self, $name) = @_;
     $self->field($name, sub {
-                     return WebService::Braintree::IsNode->new(searcher => shift, name => $name);
-                 });
+        return WebService::Braintree::IsNode->new(searcher => shift, name => $name);
+    });
 }
 
 sub equality {
     my ($self, $name) = @_;
     $self->field($name, sub {
-                     return WebService::Braintree::EqualityNode->new(searcher => shift, name => $name);
-                 });
+        return WebService::Braintree::EqualityNode->new(searcher => shift, name => $name);
+    });
 }
 
 sub text {
     my ($self, $name) = @_;
     $self->field($name, sub {
-                     return WebService::Braintree::TextNode->new(searcher => shift, name => $name);
-                 });
+        return WebService::Braintree::TextNode->new(searcher => shift, name => $name);
+    });
 }
 
 sub key_value {
     my ($self, $name) = @_;
     $self->field($name, sub {
-                     return WebService::Braintree::KeyValueNode->new(searcher => shift, name => $name);
-                 });
+        return WebService::Braintree::KeyValueNode->new(searcher => shift, name => $name);
+    });
 }
 
 sub range {
     my ($self, $name) = @_;
     $self->field($name, sub {
-                     return WebService::Braintree::RangeNode->new(searcher => shift, name => $name);
-                 });
+        return WebService::Braintree::RangeNode->new(searcher => shift, name => $name);
+    });
 }
 
 sub multiple_values {
@@ -51,7 +51,8 @@ sub multiple_values {
         return WebService::Braintree::MultipleValuesNode->new(
             searcher => shift,
             name => $name,
-            allowed_values => @allowed_values ? [@allowed_values] : undef)
+            allowed_values => @allowed_values ? [@allowed_values] : undef,
+        );
     };
     $self->field($name, $node);
 }
@@ -59,8 +60,8 @@ sub multiple_values {
 sub partial_match {
     my ($self, $name) = @_;
     $self->field($name, sub {
-                     return WebService::Braintree::PartialMatchNode->new(searcher => shift, name => $name);
-                 });
+        return WebService::Braintree::PartialMatchNode->new(searcher => shift, name => $name);
+    });
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/WebService/Braintree/AdvancedSearchNodes.pm
+++ b/lib/WebService/Braintree/AdvancedSearchNodes.pm
@@ -1,11 +1,17 @@
 {
     package WebService::Braintree::AdvancedSearchNodes;
 
+    use 5.010_001;
+    use strictures 1;
+
     use Moose;
 }
 
 {
     package WebService::Braintree::SearchNode;
+
+    use 5.010_001;
+    use strictures 1;
 
     use Moose;
 
@@ -35,6 +41,9 @@
 {
     package WebService::Braintree::IsNode;
 
+    use 5.010_001;
+    use strictures 1;
+
     use Moose;
     extends ("WebService::Braintree::SearchNode");
 
@@ -49,6 +58,9 @@
 {
     package WebService::Braintree::EqualityNode;
 
+    use 5.010_001;
+    use strictures 1;
+
     use Moose;
     extends ("WebService::Braintree::IsNode");
 
@@ -62,6 +74,9 @@
 
 {
     package WebService::Braintree::KeyValueNode;
+
+    use 5.010_001;
+    use strictures 1;
 
     use Moose;
     extends ("WebService::Braintree::SearchNode");
@@ -87,6 +102,9 @@
 {
     package WebService::Braintree::PartialMatchNode;
 
+    use 5.010_001;
+    use strictures 1;
+
     use Moose;
     extends ("WebService::Braintree::EqualityNode");
 
@@ -106,6 +124,9 @@
 {
     package WebService::Braintree::TextNode;
 
+    use 5.010_001;
+    use strictures 1;
+
     use Moose;
     extends ("WebService::Braintree::PartialMatchNode");
 
@@ -119,6 +140,9 @@
 
 {
     package WebService::Braintree::RangeNode;
+
+    use 5.010_001;
+    use strictures 1;
 
     use Moose;
     extends ("WebService::Braintree::EqualityNode");
@@ -146,6 +170,9 @@
 
 {
     package WebService::Braintree::MultipleValuesNode;
+
+    use 5.010_001;
+    use strictures 1;
 
     use Carp;
     use Moose;

--- a/lib/WebService/Braintree/ApplePayCard.pm
+++ b/lib/WebService/Braintree/ApplePayCard.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::ApplePayCard;
 
+use 5.010_001;
+use strictures 1;
+
 use WebService::Braintree::ApplePayCard::CardType;
 
 use Moose;

--- a/lib/WebService/Braintree/ApplePayCard/CardType.pm
+++ b/lib/WebService/Braintree/ApplePayCard/CardType.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ApplePayCard::CardType;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant AmericanExpress => "Apple Pay - American Express";
 use constant MasterCard => "Apple Pay - MasterCard";

--- a/lib/WebService/Braintree/ClientToken.pm
+++ b/lib/WebService/Braintree/ClientToken.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::ClientToken;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::ClientToken

--- a/lib/WebService/Braintree/ClientTokenGateway.pm
+++ b/lib/WebService/Braintree/ClientTokenGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::ClientTokenGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 with 'WebService::Braintree::Role::MakeRequest';
 

--- a/lib/WebService/Braintree/Configuration.pm
+++ b/lib/WebService/Braintree/Configuration.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::Configuration;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::Configuration

--- a/lib/WebService/Braintree/CreditCard.pm
+++ b/lib/WebService/Braintree/CreditCard.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::CreditCard;
 
+use 5.010_001;
+use strictures 1;
+
 use WebService::Braintree::CreditCard::CardType;
 use WebService::Braintree::CreditCard::Location;
 use WebService::Braintree::CreditCard::Prepaid;

--- a/lib/WebService/Braintree/CreditCard/CardType.pm
+++ b/lib/WebService/Braintree/CreditCard/CardType.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::CreditCard::CardType;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant AmericanExpress => "American Express";
 use constant CarteBlanche => "Carte Blanche";

--- a/lib/WebService/Braintree/CreditCard/Commercial.pm
+++ b/lib/WebService/Braintree/CreditCard/Commercial.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::CreditCard::Commercial;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant Yes => "Yes";
 use constant No => "No";

--- a/lib/WebService/Braintree/CreditCard/CountryOfIssuance.pm
+++ b/lib/WebService/Braintree/CreditCard/CountryOfIssuance.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::CreditCard::CountryOfIssuance;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant Yes => "Yes";
 use constant No => "No";

--- a/lib/WebService/Braintree/CreditCard/Debit.pm
+++ b/lib/WebService/Braintree/CreditCard/Debit.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::CreditCard::Debit;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant Yes => "Yes";
 use constant No => "No";

--- a/lib/WebService/Braintree/CreditCard/DurbinRegulated.pm
+++ b/lib/WebService/Braintree/CreditCard/DurbinRegulated.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::CreditCard::DurbinRegulated;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant Yes => "Yes";
 use constant No => "No";

--- a/lib/WebService/Braintree/CreditCard/Healthcare.pm
+++ b/lib/WebService/Braintree/CreditCard/Healthcare.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::CreditCard::Healthcare;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant Yes => "Yes";
 use constant No => "No";

--- a/lib/WebService/Braintree/CreditCard/IssuingBank.pm
+++ b/lib/WebService/Braintree/CreditCard/IssuingBank.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::CreditCard::IssuingBank;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant Yes => "Yes";
 use constant No => "No";

--- a/lib/WebService/Braintree/CreditCard/Location.pm
+++ b/lib/WebService/Braintree/CreditCard/Location.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::CreditCard::Location;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant International => "international";
 use constant US => "us";

--- a/lib/WebService/Braintree/CreditCard/Payroll.pm
+++ b/lib/WebService/Braintree/CreditCard/Payroll.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::CreditCard::Payroll;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant Yes => "Yes";
 use constant No => "No";

--- a/lib/WebService/Braintree/CreditCard/Prepaid.pm
+++ b/lib/WebService/Braintree/CreditCard/Prepaid.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::CreditCard::Prepaid;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant Yes => "Yes";
 use constant No => "No";

--- a/lib/WebService/Braintree/CreditCardGateway.pm
+++ b/lib/WebService/Braintree/CreditCardGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::CreditCardGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 with 'WebService::Braintree::Role::MakeRequest';
 

--- a/lib/WebService/Braintree/CreditCardVerification.pm
+++ b/lib/WebService/Braintree/CreditCardVerification.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::CreditCardVerification;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::CreditCardVerification

--- a/lib/WebService/Braintree/CreditCardVerificationGateway.pm
+++ b/lib/WebService/Braintree/CreditCardVerificationGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::CreditCardVerificationGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 use WebService::Braintree::CreditCardVerificationSearch;
 use WebService::Braintree::Util qw(validate_id to_instance_array);

--- a/lib/WebService/Braintree/CreditCardVerificationSearch.pm
+++ b/lib/WebService/Braintree/CreditCardVerificationSearch.pm
@@ -1,9 +1,11 @@
 package WebService::Braintree::CreditCardVerificationSearch;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 use WebService::Braintree::CreditCard::CardType;
 use WebService::Braintree::AdvancedSearch;
-
 
 my $field = WebService::Braintree::AdvancedSearchFields->new(metaclass => __PACKAGE__->meta);
 $field->text("id");

--- a/lib/WebService/Braintree/Customer.pm
+++ b/lib/WebService/Braintree/Customer.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::Customer;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::Customer

--- a/lib/WebService/Braintree/CustomerGateway.pm
+++ b/lib/WebService/Braintree/CustomerGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::CustomerGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 with 'WebService::Braintree::Role::MakeRequest';
 

--- a/lib/WebService/Braintree/CustomerSearch.pm
+++ b/lib/WebService/Braintree/CustomerSearch.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::CustomerSearch;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 use WebService::Braintree::AdvancedSearch;
 

--- a/lib/WebService/Braintree/Digest.pm
+++ b/lib/WebService/Braintree/Digest.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Digest;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use Digest::HMAC_SHA1 qw(hmac_sha1 hmac_sha1_hex);
 use Digest::SHA1;

--- a/lib/WebService/Braintree/DigestSHA256.pm
+++ b/lib/WebService/Braintree/DigestSHA256.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::DigestSHA256;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use Digest;
 use Digest::SHA;

--- a/lib/WebService/Braintree/Disbursement.pm
+++ b/lib/WebService/Braintree/Disbursement.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::Disbursement;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::Disbursement

--- a/lib/WebService/Braintree/DisbursementDetails.pm
+++ b/lib/WebService/Braintree/DisbursementDetails.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::DisbursementDetails;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 extends 'WebService::Braintree::ResultObject';
 

--- a/lib/WebService/Braintree/Dispute.pm
+++ b/lib/WebService/Braintree/Dispute.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::Dispute;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::Dispute

--- a/lib/WebService/Braintree/Dispute/Reason.pm
+++ b/lib/WebService/Braintree/Dispute/Reason.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Dispute::Reason;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant CancelledRecurringTransaction => "cancelled_recurring_transaction";
 use constant CreditNotProcessed => "credit_not_processed";

--- a/lib/WebService/Braintree/Dispute/Status.pm
+++ b/lib/WebService/Braintree/Dispute/Status.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Dispute::Status;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant Open => 'open';
 use constant Won => 'won';

--- a/lib/WebService/Braintree/Dispute/TransactionDetails.pm
+++ b/lib/WebService/Braintree/Dispute/TransactionDetails.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::Dispute::TransactionDetails;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::Dispute::TransactionDetails

--- a/lib/WebService/Braintree/ErrorCodes.pm
+++ b/lib/WebService/Braintree/ErrorCodes.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use WebService::Braintree::ErrorCodes::Address;
 use WebService::Braintree::ErrorCodes::ApplePay;

--- a/lib/WebService/Braintree/ErrorCodes/Address.pm
+++ b/lib/WebService/Braintree/ErrorCodes/Address.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::Address;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant CannotBeBlank                   => "81801";
 use constant CompanyIsInvalid                => "91821";

--- a/lib/WebService/Braintree/ErrorCodes/AltPay.pm
+++ b/lib/WebService/Braintree/ErrorCodes/AltPay.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::AltPay;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant PayPalAccountCannotHaveBothAccessTokenAndConsentCode   => "82903";
 use constant PayPalAccountCannotVaultOneTimeUsePayPalAccount        => "82902";

--- a/lib/WebService/Braintree/ErrorCodes/ApplePay.pm
+++ b/lib/WebService/Braintree/ErrorCodes/ApplePay.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::ApplePay;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant ApplePayCardsAreNotAccepted                      => "83501";
 use constant CustomerIdIsRequiredForVaulting                  => "83502";

--- a/lib/WebService/Braintree/ErrorCodes/AuthorizationFingerprint.pm
+++ b/lib/WebService/Braintree/ErrorCodes/AuthorizationFingerprint.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::AuthorizationFingerprint;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant InvalidCreatedAt                  => "93204";
 use constant InvalidFormat                     => "93202";

--- a/lib/WebService/Braintree/ErrorCodes/ClientToken.pm
+++ b/lib/WebService/Braintree/ErrorCodes/ClientToken.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::ClientToken;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant CustomerDoesNotExist                            => "92804";
 use constant FailOnDuplicatePaymentMethodRequiresCustomerId  => "92803";

--- a/lib/WebService/Braintree/ErrorCodes/CreditCard.pm
+++ b/lib/WebService/Braintree/ErrorCodes/CreditCard.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::CreditCard;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant BillingAddressConflict                                   => "91701";
 use constant BillingAddressIdIsInvalid                                => "91702";

--- a/lib/WebService/Braintree/ErrorCodes/CreditCard/Options.pm
+++ b/lib/WebService/Braintree/ErrorCodes/CreditCard/Options.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::CreditCard::Options;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant UpdateExistingTokenIsInvalid           => "91723";
 use constant UseBillingForShippingDisabled          => "91572";

--- a/lib/WebService/Braintree/ErrorCodes/Customer.pm
+++ b/lib/WebService/Braintree/ErrorCodes/Customer.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::Customer;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant CompanyIsTooLong       => "81601";
 use constant CustomFieldIsInvalid   => "91602";

--- a/lib/WebService/Braintree/ErrorCodes/Descriptor.pm
+++ b/lib/WebService/Braintree/ErrorCodes/Descriptor.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::Descriptor;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant DynamicDescriptorsDisabled        => "92203";
 use constant InternationalPhoneFormatIsInvalid => "92205";

--- a/lib/WebService/Braintree/ErrorCodes/IndustryType.pm
+++ b/lib/WebService/Braintree/ErrorCodes/IndustryType.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::IndustryType;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant CheckInDateIsInvalid               => "93404";
 use constant CheckOutDateIsInvalid              => "93405";

--- a/lib/WebService/Braintree/ErrorCodes/MerchantAccount.pm
+++ b/lib/WebService/Braintree/ErrorCodes/MerchantAccount.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::MerchantAccount;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant IdIsNotAllowed                         => "82605";
 use constant IdIsTooLong                            => "82602";

--- a/lib/WebService/Braintree/ErrorCodes/MerchantAccount/ApplicantDetails.pm
+++ b/lib/WebService/Braintree/ErrorCodes/MerchantAccount/ApplicantDetails.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::MerchantAccount::ApplicantDetails;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant AccountNumberIsRequired        => "82614";
 use constant CompanyNameIsInvalid           => "82631";

--- a/lib/WebService/Braintree/ErrorCodes/MerchantAccount/ApplicantDetails/Address.pm
+++ b/lib/WebService/Braintree/ErrorCodes/MerchantAccount/ApplicantDetails/Address.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::MerchantAccount::ApplicantDetails::Address;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant LocalityIsRequired      => "82618";
 use constant PostalCodeIsInvalid     => "82630";

--- a/lib/WebService/Braintree/ErrorCodes/MerchantAccount/Business.pm
+++ b/lib/WebService/Braintree/ErrorCodes/MerchantAccount/Business.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::MerchantAccount::Business;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant DbaNameIsInvalid             => "82646";
 use constant TaxIdIsInvalid               => "82647";

--- a/lib/WebService/Braintree/ErrorCodes/MerchantAccount/Business/Address.pm
+++ b/lib/WebService/Braintree/ErrorCodes/MerchantAccount/Business/Address.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::MerchantAccount::Business::Address;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant RegionIsInvalid        => "82684";
 use constant StreetAddressIsInvalid => "82685";

--- a/lib/WebService/Braintree/ErrorCodes/MerchantAccount/Funding.pm
+++ b/lib/WebService/Braintree/ErrorCodes/MerchantAccount/Funding.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::MerchantAccount::Funding;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant RoutingNumberIsRequired => "82640";
 use constant AccountNumberIsRequired => "82641";

--- a/lib/WebService/Braintree/ErrorCodes/MerchantAccount/Individual.pm
+++ b/lib/WebService/Braintree/ErrorCodes/MerchantAccount/Individual.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::MerchantAccount::Individual;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant FirstNameIsRequired    => "82637";
 use constant LastNameIsRequired     => "82638";

--- a/lib/WebService/Braintree/ErrorCodes/MerchantAccount/Individual/Address.pm
+++ b/lib/WebService/Braintree/ErrorCodes/MerchantAccount/Individual/Address.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::MerchantAccount::Individual::Address;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant StreetAddressIsRequired => "82657";
 use constant LocalityIsRequired      => "82658";

--- a/lib/WebService/Braintree/ErrorCodes/PayPalAccount.pm
+++ b/lib/WebService/Braintree/ErrorCodes/PayPalAccount.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::PayPalAccount;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant CannotCloneTransactionWithPayPalAccount => "91573";
 use constant CannotVaultOneTimeUsePayPalAccount      => "82902";

--- a/lib/WebService/Braintree/ErrorCodes/PaymentMethod.pm
+++ b/lib/WebService/Braintree/ErrorCodes/PaymentMethod.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::PaymentMethod;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant CustomerIdIsRequired           => "93104";
 use constant CustomerIdIsInvalid            => "93105";

--- a/lib/WebService/Braintree/ErrorCodes/SettlementBatchSummary.pm
+++ b/lib/WebService/Braintree/ErrorCodes/SettlementBatchSummary.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::SettlementBatchSummary;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant CustomFieldIsInvalid     => "82303";
 use constant SettlementDateIsInvalid  => "82302";

--- a/lib/WebService/Braintree/ErrorCodes/Subscription.pm
+++ b/lib/WebService/Braintree/ErrorCodes/Subscription.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::Subscription;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant BillingDayOfMonthCannotBeUpdated                   => "91918";
 use constant BillingDayOfMonthIsInvalid                         => "91914";

--- a/lib/WebService/Braintree/ErrorCodes/Subscription/Modification.pm
+++ b/lib/WebService/Braintree/ErrorCodes/Subscription/Modification.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::Subscription::Modification;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant AmountCannotBeBlank                          => "92003";
 use constant AmountIsInvalid                              => "92002";

--- a/lib/WebService/Braintree/ErrorCodes/Transaction.pm
+++ b/lib/WebService/Braintree/ErrorCodes/Transaction.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::Transaction;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant AmountCannotBeNegative                            => "81501";
 use constant AmountFormatIsInvalid                             => "81503";

--- a/lib/WebService/Braintree/ErrorCodes/Transaction/Options.pm
+++ b/lib/WebService/Braintree/ErrorCodes/Transaction/Options.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::ErrorCodes::Transaction::Options;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant SubmitForSettlementIsRequiredForCloning => "91544";
 use constant VaultIsDisabled                         => "91525";

--- a/lib/WebService/Braintree/Gateway.pm
+++ b/lib/WebService/Braintree/Gateway.pm
@@ -1,5 +1,7 @@
 package WebService::Braintree::Gateway;
 
+use 5.010_001;
+use strictures 1;
 
 use WebService::Braintree::AddressGateway;
 use WebService::Braintree::ClientTokenGateway;

--- a/lib/WebService/Braintree/HTTP.pm
+++ b/lib/WebService/Braintree/HTTP.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::HTTP;
 
+use 5.010_001;
+use strictures 1;
+
 use HTTP::Request;
 use LWP::UserAgent;
 

--- a/lib/WebService/Braintree/MerchantAccount.pm
+++ b/lib/WebService/Braintree/MerchantAccount.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::MerchantAccount;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::Customer
@@ -60,6 +63,9 @@ sub gateway {
 {
     package WebService::Braintree::MerchantAccount::Status;
 
+    use 5.010_001;
+    use strictures 1;
+
     use constant Active => "active";
     use constant Pending => "pending";
     use constant Suspended => "suspended";
@@ -67,6 +73,9 @@ sub gateway {
 
 {
     package WebService::Braintree::MerchantAccount::FundingDestination;
+
+    use 5.010_001;
+    use strictures 1;
 
     use constant Bank => "bank";
     use constant Email => "email";

--- a/lib/WebService/Braintree/MerchantAccount/AddressDetails.pm
+++ b/lib/WebService/Braintree/MerchantAccount/AddressDetails.pm
@@ -1,5 +1,7 @@
 package WebService::Braintree::MerchantAccount::AddressDetails;
 
+use 5.010_001;
+use strictures 1;
 
 use Moose;
 extends "WebService::Braintree::ResultObject";

--- a/lib/WebService/Braintree/MerchantAccount/BusinessDetails.pm
+++ b/lib/WebService/Braintree/MerchantAccount/BusinessDetails.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::MerchantAccount::BusinessDetails;
 
+use 5.010_001;
+use strictures 1;
+
 use WebService::Braintree::MerchantAccount::AddressDetails;
 
 use Moose;

--- a/lib/WebService/Braintree/MerchantAccount/FundingDetails.pm
+++ b/lib/WebService/Braintree/MerchantAccount/FundingDetails.pm
@@ -1,5 +1,7 @@
 package WebService::Braintree::MerchantAccount::FundingDetails;
 
+use 5.010_001;
+use strictures 1;
 
 use Moose;
 extends "WebService::Braintree::ResultObject";

--- a/lib/WebService/Braintree/MerchantAccount/IndividualDetails.pm
+++ b/lib/WebService/Braintree/MerchantAccount/IndividualDetails.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::MerchantAccount::IndividualDetails;
 
+use 5.010_001;
+use strictures 1;
+
 use WebService::Braintree::MerchantAccount::AddressDetails;
 
 use Moose;

--- a/lib/WebService/Braintree/MerchantAccountGateway.pm
+++ b/lib/WebService/Braintree/MerchantAccountGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::MerchantAccountGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 with 'WebService::Braintree::Role::MakeRequest';
 

--- a/lib/WebService/Braintree/Nonce.pm
+++ b/lib/WebService/Braintree/Nonce.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::Nonce;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 extends 'WebService::Braintree::ResultObject';
 

--- a/lib/WebService/Braintree/PartnerMerchant.pm
+++ b/lib/WebService/Braintree/PartnerMerchant.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::PartnerMerchant;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::PartnerMerchant

--- a/lib/WebService/Braintree/PayPalAccount.pm
+++ b/lib/WebService/Braintree/PayPalAccount.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::PayPalAccount;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::PayPalAccount

--- a/lib/WebService/Braintree/PayPalAccountGateway.pm
+++ b/lib/WebService/Braintree/PayPalAccountGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::PayPalAccountGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 with 'WebService::Braintree::Role::MakeRequest';
 

--- a/lib/WebService/Braintree/PayPalDetails.pm
+++ b/lib/WebService/Braintree/PayPalDetails.pm
@@ -1,5 +1,7 @@
 package WebService::Braintree::PayPalDetails;
 
+use 5.010_001;
+use strictures 1;
 
 use Moose;
 extends 'WebService::Braintree::ResultObject';

--- a/lib/WebService/Braintree/PaymentMethod.pm
+++ b/lib/WebService/Braintree/PaymentMethod.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::PaymentMethod;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::PaymentMethod

--- a/lib/WebService/Braintree/PaymentMethodGateway.pm
+++ b/lib/WebService/Braintree/PaymentMethodGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::PaymentMethodGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 with 'WebService::Braintree::Role::MakeRequest';
 

--- a/lib/WebService/Braintree/PaymentMethodNonce.pm
+++ b/lib/WebService/Braintree/PaymentMethodNonce.pm
@@ -1,20 +1,23 @@
 package WebService::Braintree::PaymentMethodNonce;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 extends 'WebService::Braintree::ResultObject';
 
 sub create {
-  my ($class, $token) = @_;
-  $class->gateway->payment_method_nonce->create($token);
+    my ($class, $token) = @_;
+    $class->gateway->payment_method_nonce->create($token);
 }
 
 sub find {
-  my ($class, $token) = @_;
-  $class->gateway->payment_method_nonce->find($token);
+    my ($class, $token) = @_;
+    $class->gateway->payment_method_nonce->find($token);
 }
 
 sub gateway {
-  return WebService::Braintree->configuration->gateway;
+    return WebService::Braintree->configuration->gateway;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/WebService/Braintree/PaymentMethodNonceGateway.pm
+++ b/lib/WebService/Braintree/PaymentMethodNonceGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::PaymentMethodNonceGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 with 'WebService::Braintree::Role::MakeRequest';
 

--- a/lib/WebService/Braintree/ResourceCollection.pm
+++ b/lib/WebService/Braintree/ResourceCollection.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::ResourceCollection;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 extends "WebService::Braintree::ResultObject";
 

--- a/lib/WebService/Braintree/Result.pm
+++ b/lib/WebService/Braintree/Result.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::Result;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 use Hash::Inflator;
 

--- a/lib/WebService/Braintree/ResultObject.pm
+++ b/lib/WebService/Braintree/ResultObject.pm
@@ -2,7 +2,6 @@ package WebService::Braintree::ResultObject;
 
 use Moose;
 use WebService::Braintree::Util qw(is_arrayref is_hashref);
-use Scalar::Util qw(blessed);
 
 sub set_attributes_from_hash {
     my ($self, $target, $attributes) = @_;
@@ -15,10 +14,7 @@ sub set_attributes_from_hash {
 sub set_attr_value {
     my ($self, $value) = @_;
 
-    if (blessed($value)) {
-        return $value;
-    }
-    elsif (is_hashref($value)) {
+    if (is_hashref($value)) {
         return Hash::Inflator->new($value);
     } elsif (is_arrayref($value)) {
         my $new_array = [];

--- a/lib/WebService/Braintree/ResultObject.pm
+++ b/lib/WebService/Braintree/ResultObject.pm
@@ -58,7 +58,6 @@ sub setup_sub_objects {
     }
 }
 
-
 sub credit_card_details { shift->credit_card; }
 sub customer_details { shift->customer; }
 sub billing_details { shift->billing; }

--- a/lib/WebService/Braintree/ResultObject.pm
+++ b/lib/WebService/Braintree/ResultObject.pm
@@ -2,6 +2,7 @@ package WebService::Braintree::ResultObject;
 
 use Moose;
 use WebService::Braintree::Util qw(is_arrayref is_hashref);
+use Scalar::Util qw(blessed);
 
 sub set_attributes_from_hash {
     my ($self, $target, $attributes) = @_;
@@ -14,7 +15,10 @@ sub set_attributes_from_hash {
 sub set_attr_value {
     my ($self, $value) = @_;
 
-    if (is_hashref($value)) {
+    if (blessed($value)) {
+        return $value;
+    }
+    elsif (is_hashref($value)) {
         return Hash::Inflator->new($value);
     } elsif (is_arrayref($value)) {
         my $new_array = [];

--- a/lib/WebService/Braintree/ResultObject.pm
+++ b/lib/WebService/Braintree/ResultObject.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::ResultObject;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 use WebService::Braintree::Util qw(is_arrayref is_hashref);
 

--- a/lib/WebService/Braintree/Role/MakeRequest.pm
+++ b/lib/WebService/Braintree/Role/MakeRequest.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::Role::MakeRequest;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose::Role;
 
 sub _make_request {

--- a/lib/WebService/Braintree/SettlementBatchSummary.pm
+++ b/lib/WebService/Braintree/SettlementBatchSummary.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::SettlementBatchSummary;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::SettlementBatchSummary

--- a/lib/WebService/Braintree/SettlementBatchSummaryGateway.pm
+++ b/lib/WebService/Braintree/SettlementBatchSummaryGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::SettlementBatchSummaryGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 with 'WebService::Braintree::Role::MakeRequest';
 use Carp qw(confess);

--- a/lib/WebService/Braintree/Subscription.pm
+++ b/lib/WebService/Braintree/Subscription.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::Subscription;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::Subscription

--- a/lib/WebService/Braintree/Subscription/Status.pm
+++ b/lib/WebService/Braintree/Subscription/Status.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Subscription::Status;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant Active => 'Active';
 use constant Canceled => 'Canceled';

--- a/lib/WebService/Braintree/SubscriptionGateway.pm
+++ b/lib/WebService/Braintree/SubscriptionGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::SubscriptionGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use WebService::Braintree::Util qw(to_instance_array validate_id);
 use Carp qw(confess);
 

--- a/lib/WebService/Braintree/SubscriptionSearch.pm
+++ b/lib/WebService/Braintree/SubscriptionSearch.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::SubscriptionSearch;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 use WebService::Braintree::AdvancedSearch;
 

--- a/lib/WebService/Braintree/Test.pm
+++ b/lib/WebService/Braintree/Test.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Test;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use WebService::Braintree::Test::VenmoSdk;
 

--- a/lib/WebService/Braintree/Test/MerchantAccount.pm
+++ b/lib/WebService/Braintree/Test/MerchantAccount.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Test::MerchantAccount;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use vars qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS );
 use Exporter qw(import);

--- a/lib/WebService/Braintree/Test/VenmoSdk.pm
+++ b/lib/WebService/Braintree/Test/VenmoSdk.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Test::VenmoSdk;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use vars qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS );
 use Exporter qw(import);

--- a/lib/WebService/Braintree/Transaction.pm
+++ b/lib/WebService/Braintree/Transaction.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::Transaction;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::Transaction

--- a/lib/WebService/Braintree/Transaction/CreatedUsing.pm
+++ b/lib/WebService/Braintree/Transaction/CreatedUsing.pm
@@ -1,5 +1,7 @@
 package WebService::Braintree::Transaction::CreatedUsing;
 
+use 5.010_001;
+use strictures 1;
 
 use constant Token => "token";
 use constant FullInformation => "full_information";

--- a/lib/WebService/Braintree/Transaction/EscrowStatus.pm
+++ b/lib/WebService/Braintree/Transaction/EscrowStatus.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Transaction::EscrowStatus;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant HoldPending => 'hold_pending';
 use constant Held => 'held';

--- a/lib/WebService/Braintree/Transaction/PaymentInstrumentType.pm
+++ b/lib/WebService/Braintree/Transaction/PaymentInstrumentType.pm
@@ -1,7 +1,9 @@
 package WebService::Braintree::Transaction::PaymentInstrumentType;
 
+use 5.010_001;
+use strictures 1;
 
-use vars qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS );
+use vars qw(@ISA @EXPORT @EXPORT_OK);
 use Exporter;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(PAYPAL_ACCOUNT SEPA_BANK_ACCOUNT CREDIT_CARD ANY UNKNOWN);

--- a/lib/WebService/Braintree/Transaction/Source.pm
+++ b/lib/WebService/Braintree/Transaction/Source.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Transaction::Source;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant Api => "api";
 use constant ControlPanel => "control_panel";

--- a/lib/WebService/Braintree/Transaction/Status.pm
+++ b/lib/WebService/Braintree/Transaction/Status.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Transaction::Status;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant AuthorizationExpired => 'authorization_expired';
 use constant Authorizing => 'authorizing';

--- a/lib/WebService/Braintree/Transaction/Type.pm
+++ b/lib/WebService/Braintree/Transaction/Type.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Transaction::Type;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant Sale => "sale";
 use constant Credit => "credit";

--- a/lib/WebService/Braintree/TransactionGateway.pm
+++ b/lib/WebService/Braintree/TransactionGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::TransactionGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 with 'WebService::Braintree::Role::MakeRequest';
 use Carp qw(confess);

--- a/lib/WebService/Braintree/TransactionSearch.pm
+++ b/lib/WebService/Braintree/TransactionSearch.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::TransactionSearch;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 use WebService::Braintree::AdvancedSearch;
 

--- a/lib/WebService/Braintree/TransparentRedirect.pm
+++ b/lib/WebService/Braintree/TransparentRedirect.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::TransparentRedirect;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::TransparentRedirect

--- a/lib/WebService/Braintree/TransparentRedirect/QueryString.pm
+++ b/lib/WebService/Braintree/TransparentRedirect/QueryString.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::TransparentRedirect::QueryString;
 
+use 5.010_001;
+use strictures 1;
+
 use URI;
 use WebService::Braintree::Digest qw(hexdigest);
 use Moose;

--- a/lib/WebService/Braintree/TransparentRedirectGateway.pm
+++ b/lib/WebService/Braintree/TransparentRedirectGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::TransparentRedirectGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 with 'WebService::Braintree::Role::MakeRequest';
 

--- a/lib/WebService/Braintree/UnknownPaymentMethod.pm
+++ b/lib/WebService/Braintree/UnknownPaymentMethod.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::UnknownPaymentMethod;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 extends 'WebService::Braintree::PaymentMethod';
 

--- a/lib/WebService/Braintree/Util.pm
+++ b/lib/WebService/Braintree/Util.pm
@@ -68,7 +68,6 @@ sub to_instance_array {
     return \@result;
 }
 
-# USED all over the place, UNCOVERED?
 sub validate_id {
     my $id = shift;
 

--- a/lib/WebService/Braintree/Util.pm
+++ b/lib/WebService/Braintree/Util.pm
@@ -68,6 +68,7 @@ sub to_instance_array {
     return \@result;
 }
 
+# USED all over the place, UNCOVERED?
 sub validate_id {
     my $id = shift;
 

--- a/lib/WebService/Braintree/Util.pm
+++ b/lib/WebService/Braintree/Util.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Util;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use vars qw(@ISA @EXPORT_OK);
 use Exporter qw(import);

--- a/lib/WebService/Braintree/ValidationErrorCollection.pm
+++ b/lib/WebService/Braintree/ValidationErrorCollection.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::ValidationErrorCollection;
 
+use 5.010_001;
+use strictures 1;
+
 =head1 NAME
 
 WebService::Braintree::ValidationError

--- a/lib/WebService/Braintree/Validations.pm
+++ b/lib/WebService/Braintree/Validations.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Validations;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use WebService::Braintree::Util qw(is_hashref);
 

--- a/lib/WebService/Braintree/WebhookNotification.pm
+++ b/lib/WebService/Braintree/WebhookNotification.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::WebhookNotification;
 
+use 5.010_001;
+use strictures 1;
+
 use WebService::Braintree::Util qw(is_hashref);
 
 =head1 NAME

--- a/lib/WebService/Braintree/WebhookNotification/Kind.pm
+++ b/lib/WebService/Braintree/WebhookNotification/Kind.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::WebhookNotification::Kind;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant PartnerMerchantConnected => "partner_merchant_connected";
 use constant PartnerMerchantDisconnected => "partner_merchant_disconnected";

--- a/lib/WebService/Braintree/WebhookNotificationGateway.pm
+++ b/lib/WebService/Braintree/WebhookNotificationGateway.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::WebhookNotificationGateway;
 
+use 5.010_001;
+use strictures 1;
+
 use MIME::Base64;
 use WebService::Braintree::Digest qw(hexdigest);
 use WebService::Braintree::Xml qw(xml_to_hash);

--- a/lib/WebService/Braintree/WebhookTesting.pm
+++ b/lib/WebService/Braintree/WebhookTesting.pm
@@ -1,5 +1,8 @@
 package WebService::Braintree::WebhookTesting;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 
 sub sample_notification {

--- a/lib/WebService/Braintree/WebhookTestingGateway.pm
+++ b/lib/WebService/Braintree/WebhookTestingGateway.pm
@@ -1,5 +1,7 @@
 package WebService::Braintree::WebhookTestingGateway;
 
+use 5.010_001;
+use strictures 1;
 
 use MIME::Base64;
 use POSIX qw(strftime);

--- a/lib/WebService/Braintree/Xml.pm
+++ b/lib/WebService/Braintree/Xml.pm
@@ -1,6 +1,7 @@
 package WebService::Braintree::Xml;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use vars qw(@ISA @EXPORT_OK);
 use Exporter;

--- a/run_tests
+++ b/run_tests
@@ -61,6 +61,7 @@ elif [[ "$1" == "test" ]]; then
             $fix_for_root_user_in_container \
             -v $(pwd)/lib:/app/lib \
             -v $(pwd)/t:/app/t \
+            -v $(pwd)/.git:/app/.git \
             ${container}:${version} \
                 $test_command
     done
@@ -83,6 +84,7 @@ elif [[ "$1" == "integration" ]]; then
             -v $(pwd)/t:/app/t \
             -v $(pwd)/xt:/app/xt \
             -v $(pwd)/sandbox_config.json:/app/sandbox_config.json \
+            -v $(pwd)/.git:/app/.git \
             ${container}:${version} \
                 $test_command
     done
@@ -101,6 +103,7 @@ elif [[ "$1" == "cover" ]]; then
             -v $(pwd)/lib:/app/lib \
             -v $(pwd)/t:/app/t \
             -v $(pwd)/cover_db:/app/cover_db \
+            -v $(pwd)/.git:/app/.git \
             ${container}:${version} \
                 cover
 
@@ -128,6 +131,7 @@ elif [[ "$1" == "release" ]]; then
         Changes LICENSE
         Makefile.PL inc
         MANIFEST MANIFEST.SKIP
+        .git
     )
 
     volumes=(-v $(pwd)/.pause:/root/.pause)

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/address.t
+++ b/t/address.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/advanced_search.t
+++ b/t/advanced_search.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);
@@ -19,8 +22,6 @@ use WebService::Braintree::TestHelper;
     $field->multiple_values("created_using", "full_information", "token");
     $field->multiple_values("ids");
     $field->key_value("refund");
-
-
 
     __PACKAGE__->meta->make_immutable;;
     1;
@@ -43,14 +44,14 @@ subtest "Equality Nodes" => sub {
     {
         my $search = WebService::Braintree::AdvancedSearchTest->new;
         $search->order_id->is("2132");
-        $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
+        my $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
         is $result_hash->{'order_id'}->{'is'}, "2132";
     }
 
     {
         my $search = WebService::Braintree::AdvancedSearchTest->new;
         $search->credit_card_expiration_date->is_not("12/11");
-        $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
+        my $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
         is $result_hash->{'credit_card_expiration_date'}->{'is_not'}, "12/11";
     }
 
@@ -65,7 +66,7 @@ subtest "Equality Nodes" => sub {
         my $search = WebService::Braintree::AdvancedSearchTest->new;
         $search->order_id->is("2132");
         $search->order_id->is("4376");
-        $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
+        my $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
         is $result_hash->{'order_id'}->{'is'}, "4376";
     };
 };
@@ -73,36 +74,36 @@ subtest "Equality Nodes" => sub {
 subtest "Partial Matches" => sub {
     my $search = WebService::Braintree::AdvancedSearchTest->new;
     $search->billing_company->starts_with("Brain");
-    $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
+    my $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
     is $result_hash->{'billing_company'}->{'starts_with'}, "Brain";
 };
 
 subtest "Text" => sub {
     my $search = WebService::Braintree::AdvancedSearchTest->new;
     $search->billing_company->contains("12345");
-    $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
+    my $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
     is $result_hash->{'billing_company'}->{'contains'}, "12345";
 };
 
 subtest "Range Nodes" => sub {
     {
         my $search = WebService::Braintree::AdvancedSearchTest->new;
-        $search->amount >= ("10.01");
-        $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
+        $search->amount->min("10.01");
+        my $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
         is $result_hash->{'amount'}->{'min'}, "10.01", "Minimum"
     }
 
     {
         my $search = WebService::Braintree::AdvancedSearchTest->new;
-        $search->amount <= ("10.01");
-        $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
+        $search->amount->max("10.01");
+        my $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
         is $result_hash->{'amount'}->{'max'}, "10.01", "Maximum";
     }
 
     {
         my $search = WebService::Braintree::AdvancedSearchTest->new;
         $search->amount->between("10.00", "10.02");
-        $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
+        my $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
         is $result_hash->{'amount'}->{'min'}, "10.00", "Between Min";
         is $result_hash->{'amount'}->{'max'}, "10.02", "Between Max";
     }
@@ -111,7 +112,7 @@ subtest "Range Nodes" => sub {
 subtest "Key Value Nodes" => sub {
     my $search = WebService::Braintree::AdvancedSearchTest->new;
     $search->refund->is("10.00");;
-    $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
+    my $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
     is $result_hash->{'refund'}, "10.00";
 };
 
@@ -119,7 +120,7 @@ subtest "Multiple Values Nodes" => sub {
     {
         my $search = WebService::Braintree::AdvancedSearchTest->new;
         $search->created_using->is("token");
-        $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
+        my $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
         is_deeply $result_hash->{'created_using'}, ["token"];
     }
 
@@ -127,14 +128,14 @@ subtest "Multiple Values Nodes" => sub {
         my $ids = [1, 2, 3];
         my $search = WebService::Braintree::AdvancedSearchTest->new;
         $search->ids->in($ids);
-        $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
+        my $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
         is_deeply $result_hash->{'ids'}, [1, 2, 3];
     }
 
     {
         my $search = WebService::Braintree::AdvancedSearchTest->new;
         $search->created_using->in("token", "full_information");
-        $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
+        my $result_hash = WebService::Braintree::AdvancedSearch->search_to_hash($search);
         is_deeply $result_hash->{'created_using'}, ["token", "full_information"];
     }
 

--- a/t/client_token.t
+++ b/t/client_token.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/configuration.t
+++ b/t/configuration.t
@@ -3,10 +3,10 @@
 use 5.010_001;
 use strictures 1;
 
-use lib qw(lib t/lib);
-
 use Test::More;
 use Test::Warn;
+
+use lib qw(lib t/lib);
 
 use WebService::Braintree;
 
@@ -105,8 +105,6 @@ subtest 'port()' => sub {
 subtest 'api_version()' => sub {
     is $config->api_version, 4;
 };
-
-
 
 my @examples = (
     ['sandbox', "https://api.sandbox.braintreegateway.com:443/merchants/integration_merchant_id"],

--- a/t/configuration.t
+++ b/t/configuration.t
@@ -1,5 +1,7 @@
 # vim: sw=4 ts=4 ft=perl
-use strict;
+
+use 5.010_001;
+use strictures 1;
 
 use lib qw(lib t/lib);
 

--- a/t/credit_card.t
+++ b/t/credit_card.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);
@@ -23,7 +26,7 @@ subtest "instance methods" => sub {
     is $cc->masked_number, "123456******7890";
     not_ok $cc->is_default;
 
-    $default = WebService::Braintree::CreditCard->new(default => 1);
+    my $default = WebService::Braintree::CreditCard->new(default => 1);
     ok $default->is_default;
 };
 

--- a/t/customer.t
+++ b/t/customer.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/digest.t
+++ b/t/digest.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/inflate_xml.t
+++ b/t/inflate_xml.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/lib/WebService/Braintree/ClientApiHTTP.pm
+++ b/t/lib/WebService/Braintree/ClientApiHTTP.pm
@@ -2,6 +2,9 @@
 
 package WebService::Braintree::ClientApiHTTP;
 
+use 5.010_001;
+use strictures 1;
+
 use HTTP::Request;
 use URI::Escape;
 use JSON;

--- a/t/lib/WebService/Braintree/CreditCardDefaults.pm
+++ b/t/lib/WebService/Braintree/CreditCardDefaults.pm
@@ -1,7 +1,9 @@
 # vim: sw=4 ts=4 ft=perl
 
 package WebService::Braintree::CreditCardDefaults;
-use strict;
+
+use 5.010_001;
+use strictures 1;
 
 use constant CountryOfIssuance => 'USA';
 use constant IssuingBank       => 'NETWORK ONLY';

--- a/t/lib/WebService/Braintree/CreditCardNumbers/CardTypeIndicators.pm
+++ b/t/lib/WebService/Braintree/CreditCardNumbers/CardTypeIndicators.pm
@@ -2,7 +2,8 @@
 
 package WebService::Braintree::CreditCardNumbers::CardTypeIndicators;
 
-use strict;
+use 5.010_001;
+use strictures 1;
 
 use constant Prepaid           => '4111111111111210';
 use constant Commercial        => '4111111111131010';

--- a/t/lib/WebService/Braintree/MockHTTP.pm
+++ b/t/lib/WebService/Braintree/MockHTTP.pm
@@ -2,6 +2,9 @@
 
 package WebService::Braintree::MockHTTP;
 
+use 5.010_001;
+use strictures 1;
+
 use Moose;
 
 has method => (is => 'rw');

--- a/t/lib/WebService/Braintree/Nonce.pm
+++ b/t/lib/WebService/Braintree/Nonce.pm
@@ -2,6 +2,9 @@
 
 package WebService::Braintree::Nonce;
 
+use 5.010_001;
+use strictures 1;
+
 # XXX Why aren't these constants like WebService::Braintree::SandboxValues::CreditCardNumber?
 sub transactable {
   'fake-valid-nonce';

--- a/t/lib/WebService/Braintree/SandboxValues/CreditCardNumber.pm
+++ b/t/lib/WebService/Braintree/SandboxValues/CreditCardNumber.pm
@@ -2,6 +2,9 @@
 
 package WebService::Braintree::SandboxValues::CreditCardNumber;
 
+use 5.010_001;
+use strictures 1;
+
 use vars qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS );
 use Exporter;
 our @ISA = qw(Exporter);

--- a/t/lib/WebService/Braintree/SandboxValues/TransactionAmount.pm
+++ b/t/lib/WebService/Braintree/SandboxValues/TransactionAmount.pm
@@ -2,6 +2,9 @@
 
 package WebService::Braintree::SandboxValues::TransactionAmount;
 
+use 5.010_001;
+use strictures 1;
+
 use vars qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS );
 use Exporter;
 our @ISA = qw(Exporter);

--- a/t/lib/WebService/Braintree/TestHelper.pm
+++ b/t/lib/WebService/Braintree/TestHelper.pm
@@ -2,8 +2,8 @@
 
 package WebService::Braintree::TestHelper;
 
-use strict;
-use warnings;
+use 5.010_001;
+use strictures 1;
 
 use Test::More;
 

--- a/t/manifest.t
+++ b/t/manifest.t
@@ -1,6 +1,9 @@
 #!perl -T
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use strict;

--- a/t/manifest.t
+++ b/t/manifest.t
@@ -6,9 +6,6 @@ use strictures 1;
 
 use Test::More;
 
-use strict;
-use warnings;
-
 unless ( $ENV{RELEASE_TESTING} ) {
     plan( skip_all => "Author tests not required for installation" );
 }

--- a/t/merchant_account.t
+++ b/t/merchant_account.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 use Test::Moose;
 

--- a/t/pod.t
+++ b/t/pod.t
@@ -8,9 +8,6 @@ use Test::More;
 
 use lib qw(lib t/lib);
 
-use strict;
-use warnings;
-
 # Ensure a recent version of Test::Pod
 my $min_tp = 1.22;
 eval "use Test::Pod $min_tp";

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,6 +1,9 @@
 #!perl -T
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/resource_collection.t
+++ b/t/resource_collection.t
@@ -1,8 +1,12 @@
 # vim: sw=4 ts=4 ft=perl
 
-use lib qw(lib t/lib);
+use 5.010_001;
+use strictures 1;
 
 use Test::More;
+
+use lib qw(lib t/lib);
+
 use WebService::Braintree;
 use WebService::Braintree::TestHelper;
 
@@ -15,7 +19,7 @@ subtest "each" => sub {
         return [$page_counter];
     });
 
-    @page_counts = ();
+    my @page_counts = ();
     $resource_collection->each(sub {
         push(@page_counts, shift);
     });

--- a/t/result.t
+++ b/t/result.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/subscription.t
+++ b/t/subscription.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 use Test::Moose;
 

--- a/t/transaction.t
+++ b/t/transaction.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/transparent_redirect.t
+++ b/t/transparent_redirect.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/transparent_redirect_query_string.t
+++ b/t/transparent_redirect_query_string.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/util.t
+++ b/t/util.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/validation_error.t
+++ b/t/validation_error.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/validation_error_collection.t
+++ b/t/validation_error_collection.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/validations_test.t
+++ b/t/validations_test.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/webhook_notification.t
+++ b/t/webhook_notification.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 use Test::Moose;
 

--- a/t/xml.t
+++ b/t/xml.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/t/xml_builder.t
+++ b/t/xml_builder.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/xt/sandbox/address.t
+++ b/xt/sandbox/address.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);
@@ -11,7 +14,7 @@ my $customer_instance = WebService::Braintree::Customer->new;
 my $customer = $customer_instance->create({first_name => "Walter", last_name => "Weatherman"});
 
 subtest "create" => sub {
-    $result = WebService::Braintree::Address->create({
+    my $result = WebService::Braintree::Address->create({
         customer_id => $customer->customer->id,
         first_name => "Walter",
         last_name => "Weatherman",
@@ -54,7 +57,7 @@ subtest "with a customer" => sub {
     });
 
     subtest "find" => sub {
-        $address = WebService::Braintree::Address->find($customer->customer->id, $create_result->address->id);
+        my $address = WebService::Braintree::Address->find($customer->customer->id, $create_result->address->id);
         is $address->first_name, "Walter";
     };
 

--- a/xt/sandbox/client_token.t
+++ b/xt/sandbox/client_token.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);
@@ -26,7 +29,7 @@ subtest "Generate a fingerprint that the gateway accepts" => sub {
         shared_customer_identifier_type => "testing",
     );
 
-    $result = $http->get_cards();
+    my $result = $http->get_cards();
     ok $result->is_success, "result returns no errors";
 };
 
@@ -60,14 +63,14 @@ subtest "it can pass verify card" => sub {
         shared_customer_identifier_type => "testing",
     );
 
-    $result = $http->add_card({
+    my $result = $http->add_card({
         credit_card => {
             number => "4000111111111115",
             expiration_date => "11/2099",
         },
     });
     ok $result->code == 422;
-    $response = from_json($result->content);
+    my $response = from_json($result->content);
     ok $response->{"error"}->{"message"} eq "Credit card verification failed";
 };
 
@@ -92,7 +95,7 @@ subtest "it can pass make default" => sub {
         shared_customer_identifier_type => "testing",
     );
 
-    $result = $http->add_card({
+    my $result = $http->add_card({
         credit_card => {
             number => "4111111111111111",
             expiration_date => "11/2098",
@@ -108,7 +111,7 @@ subtest "it can pass make default" => sub {
     });
     ok $result->code == 201;
 
-    $found_customer = WebService::Braintree::Customer->find($customer->id);
+    my $found_customer = WebService::Braintree::Customer->find($customer->id);
 
     foreach my $card (@{$found_customer->credit_cards}) {
         if ($card->is_default) {
@@ -143,7 +146,7 @@ subtest "it can pass fail_on_duplicate_payment_method card" => sub {
         shared_customer_identifier_type => "testing",
     );
 
-    $result = $http->add_card({
+    my $result = $http->add_card({
         credit_card => {
             number => "4111111111111111",
             expiration_date => "11/2099",
@@ -169,7 +172,7 @@ subtest "it can pass fail_on_duplicate_payment_method card" => sub {
         },
     });
     ok $result->code == 422;
-    $response = from_json($result->content);
+    my $response = from_json($result->content);
     ok $response->{"fieldErrors"}[0]->{"fieldErrors"}[0]->{"message"} eq "Duplicate card exists in the vault";
 };
 

--- a/xt/sandbox/configuration.t
+++ b/xt/sandbox/configuration.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/xt/sandbox/credit_card.t
+++ b/xt/sandbox/credit_card.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/xt/sandbox/credit_card_verification.t
+++ b/xt/sandbox/credit_card_verification.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/xt/sandbox/credit_card_verification_search.t
+++ b/xt/sandbox/credit_card_verification_search.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/xt/sandbox/customer.t
+++ b/xt/sandbox/customer.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/xt/sandbox/customer_search.t
+++ b/xt/sandbox/customer_search.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/xt/sandbox/disbursement.t
+++ b/xt/sandbox/disbursement.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/xt/sandbox/merchant_account.t
+++ b/xt/sandbox/merchant_account.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/xt/sandbox/payment_method.t
+++ b/xt/sandbox/payment_method.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/xt/sandbox/payment_method_nonce.t
+++ b/xt/sandbox/payment_method_nonce.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);
@@ -79,7 +82,7 @@ subtest "returns null 3ds_info if there isn't any" => sub {
     });
 
     my $result = WebService::Braintree::PaymentMethodNonce->find($nonce);
-    my $nonce = $result->payment_method_nonce;
+    $nonce = $result->payment_method_nonce;
     ok($result->is_success, '.. result is successful');
     is($nonce->three_d_secure_info, undef, '.. three_d_secure_info is null');
 };

--- a/xt/sandbox/paypal_account.t
+++ b/xt/sandbox/paypal_account.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/xt/sandbox/settlement_batch_summary.t
+++ b/xt/sandbox/settlement_batch_summary.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/xt/sandbox/subscription.t
+++ b/xt/sandbox/subscription.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);
@@ -181,12 +184,12 @@ TODO: {
         is $result->message, "Do Not Honor";
     };
 
-    subtest "with a subscription" => sub {
-        my $create = WebService::Braintree::Subscription->create({
-            payment_method_token => $card->credit_card->token,
-            plan_id => "integration_trialless_plan",
-        });
+    my $create = WebService::Braintree::Subscription->create({
+        payment_method_token => $card->credit_card->token,
+        plan_id => "integration_trialless_plan",
+    });
 
+    subtest "with a subscription" => sub {
         subtest "find" => sub {
             my $result = WebService::Braintree::Subscription->find($create->subscription->id);
 

--- a/xt/sandbox/subscription_search.t
+++ b/xt/sandbox/subscription_search.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);

--- a/xt/sandbox/transaction.t
+++ b/xt/sandbox/transaction.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);
@@ -37,7 +40,7 @@ TODO: {
 
     my @examples = qw(credit sale);
     foreach my $method (@examples) {
-        subtest "Successful Transaction for $example" => sub {
+        subtest "Successful Transaction for $method" => sub {
             my $result = WebService::Braintree::Transaction->$method($transaction_params);
 
             ok $result->is_success;
@@ -640,7 +643,7 @@ TODO: {
     subtest "Find" => sub {
         subtest "successful" => sub {
             my $sale_result = WebService::Braintree::Transaction->sale($transaction_params);
-            $find_result = WebService::Braintree::Transaction->find($sale_result->transaction->id);
+            my $find_result = WebService::Braintree::Transaction->find($sale_result->transaction->id);
             is $find_result->transaction->id, $sale_result->transaction->id, "should find existing transaction";
             is $find_result->transaction->amount, "50.00", "should find correct amount";
         };

--- a/xt/sandbox/transaction_search.t
+++ b/xt/sandbox/transaction_search.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);
@@ -92,7 +95,7 @@ subtest "result 'each'" => sub {
 
         is_deeply $empty_result->ids, [];
         ok $empty_result->is_empty;
-        @results = ();
+        my @results = ();
         $empty_result->each(sub { push(@results, shift); });
         is_deeply \@results, [];
     };
@@ -100,7 +103,7 @@ subtest "result 'each'" => sub {
     subtest "when one" => sub {
         my $unique = generate_unique_integer() . "each::one_result";
         my ($search_result, $transaction) = find_one_result($unique);
-        @results = ();
+        my @results = ();
         $search_result->each(sub { push(@results, shift); });
         is_deeply \@results, [$transaction];
     };

--- a/xt/sandbox/transparent_redirect.t
+++ b/xt/sandbox/transparent_redirect.t
@@ -1,5 +1,8 @@
 # vim: sw=4 ts=4 ft=perl
 
+use 5.010_001;
+use strictures 1;
+
 use Test::More;
 
 use lib qw(lib t/lib);


### PR DESCRIPTION
This adds the following preamble to all files:

```perl
use 5.010_001;
use strictures 1;
```

and fixes any fallout. I also remove all `use strict` and `use warnings` declarations as no longer relevant.