### PR TITLE
Cope with missing "Content-Length" header that sandbox braintree feels like we no longer need - also update Moo and Test::Pod dependencies to avoid errors in test, 

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -41,7 +41,7 @@ LWP = 6.02
 LWP::Protocol::https = 0
 MIME::Base64 = 0
 Module::Install::TestTarget = 0
-Moo = 0
+Moo = 1.006000 ; for coerce => 1 in attributes
 MooX::Aliases = 0
 Mozilla::CA = 0
 Scalar::Util = 0
@@ -58,5 +58,5 @@ Data::Printer = 0
 String::CamelCase = 0
 Test::Deep = 0
 Test::More = 0.98
-Test::Pod = 0
+Test::Pod = 1.41 ; for L<text|url>
 Test::Warn = 0

--- a/lib/WebService/Braintree/HTTP.pm
+++ b/lib/WebService/Braintree/HTTP.pm
@@ -87,8 +87,11 @@ sub make_request {
     warn Dumper $response->content if $ENV{WEBSERVICE_BRAINTREE_DEBUG};
 
     $self->check_response_code($response->code);
+	if (! $response->header('Content-Length') ) {
+		$response->header( 'Content-Length', length( $response->content ) );
+	}
 
-    if ($response->header('Content-Length') > 1) {
+    if (length($response->content) > 1 || $response->header('Content-Length') > 1) {
         return xml_to_hash($response->content);
     } else {
         return {http_status => $response->code};


### PR DESCRIPTION
Fixes #36 
Fixes #35