### PR TITLE
PR for #40

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,6 @@
 Revision history for WebService-Braintree
+1.8     2020-01-13
+        Adding some missing validation's fields for creating level 3 transactions
 1.7     2018-07-08
         Forgot to move some 'use Moose::Role' statements to 'use Moo::Role'
 1.6     2018-07-02

--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,7 @@ license = Perl_5
 copyright_holder = Kieren Diment
 copyright_year   = 2018
 
-version = 1.7
+version = 1.8
 
 [@Basic]
 [UploadToCPAN]

--- a/lib/WebService/Braintree/Validations.pm
+++ b/lib/WebService/Braintree/Validations.pm
@@ -245,6 +245,9 @@ sub transaction_signature{
         service_fee_amount => 1,
         three_d_secure_token => 1,
         line_items => 1,
+        shipping_amount => 1,
+        discount_amount => 1,
+        ships_from_postal_code => 1,
     };
 }
 


### PR DESCRIPTION
This is a fix for issue #40 , allows for `shipping_amount`, `shipping_from_postal_code`, and `discount_amount`.  Which are missing from the validator